### PR TITLE
Using TOM = Microsoft.AnalysisServices.Tabular namespace

### DIFF
--- a/Dax.Model.Extractor/TomExtractor.cs
+++ b/Dax.Model.Extractor/TomExtractor.cs
@@ -260,11 +260,11 @@ namespace Dax.Metadata.Extractor
             return extractor.DaxModel;
         }
 
-        public static Microsoft.AnalysisServices.Database GetDatabase(string serverName, string databaseName)
+        public static Tom.Database GetDatabase(string serverName, string databaseName)
         {
-            Microsoft.AnalysisServices.Server server = new Microsoft.AnalysisServices.Server();
+            Tom.Server server = new Tom.Server();
             server.Connect(serverName);
-            Microsoft.AnalysisServices.Database db = server.Databases.FindByName(databaseName);
+            Tom.Database db = server.Databases.FindByName(databaseName);
             // if db is null either it does not exist or we do not have admin rights to it
             if (db == null) { throw new ArgumentException($"The database '{databaseName}' could not be found. Either it does not exist or you do not have admin rights to it."); }
             return db;
@@ -272,8 +272,8 @@ namespace Dax.Metadata.Extractor
 
         public static Dax.Metadata.Model GetDaxModel(string serverName, string databaseName, string applicationName, string applicationVersion, bool readStatisticsFromData = true, int sampleRows = 0)
         {
-            Microsoft.AnalysisServices.Database db = GetDatabase(serverName, databaseName);
-            Microsoft.AnalysisServices.Tabular.Model tomModel = db.Model;
+            Tom.Database db = GetDatabase(serverName, databaseName);
+            Tom.Model tomModel = db.Model;
 
             var daxModel = Dax.Metadata.Extractor.TomExtractor.GetDaxModel(tomModel, applicationName, applicationVersion);
 

--- a/Dax.Vpax/ExportVpax.cs
+++ b/Dax.Vpax/ExportVpax.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.IO;
 using System.IO.Packaging;
 using Newtonsoft.Json;
-using Microsoft.AnalysisServices.Tabular;
+using TOM = Microsoft.AnalysisServices.Tabular;
 
 namespace Dax.Vpax
 {
@@ -27,12 +27,12 @@ namespace Dax.Vpax
             this.Package.Close();
         }
 
-        public void ExportDatabase(Microsoft.AnalysisServices.Database database)
+        public void ExportDatabase(TOM.Database database)
         {
             Uri uriTom = PackUriHelper.CreatePartUri(new Uri(VpaxFormat.TOMMODEL, UriKind.Relative));
             using (TextWriter tw = new StreamWriter(this.Package.CreatePart(uriTom, "application/json", CompressionOption.Maximum).GetStream(), Encoding.UTF8))
             {
-                tw.Write(Microsoft.AnalysisServices.JsonSerializer.SerializeDatabase(database));
+                tw.Write(TOM.JsonSerializer.SerializeDatabase(database));
                 tw.Close();
             }
         }

--- a/Dax.Vpax/ImportVpax.cs
+++ b/Dax.Vpax/ImportVpax.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.IO;
 using System.IO.Packaging;
 using Newtonsoft.Json;
-using Microsoft.AnalysisServices.Tabular;
+using TOM = Microsoft.AnalysisServices.Tabular;
 
 
 namespace Dax.Vpax
@@ -55,11 +55,11 @@ namespace Dax.Vpax
         }
         */
 
-        public Microsoft.AnalysisServices.Database ImportDatabase()
+        public TOM.Database ImportDatabase()
         {
             string modelBim = ReadPackageContentAsString(VpaxFormat.TOMMODEL);
             if (modelBim == null) return null;
-            return Microsoft.AnalysisServices.JsonSerializer.DeserializeDatabase(modelBim);
+            return TOM.JsonSerializer.DeserializeDatabase(modelBim);
         }
 
         #region IDisposable Support

--- a/Dax.Vpax/VpaxTools.cs
+++ b/Dax.Vpax/VpaxTools.cs
@@ -6,17 +6,16 @@ using System.Threading.Tasks;
 using System.IO;
 using System.IO.Packaging;
 using Newtonsoft.Json;
-using Microsoft.AnalysisServices.Tabular;
+using TOM = Microsoft.AnalysisServices.Tabular;
 
 namespace Dax.Vpax.Tools
 {
-
     public static class VpaxTools
     {
         /// <summary>
         /// Export to VertiPaq Analyzer (VPAX) stream
         /// </summary>
-        public static void ExportVpax(Stream stream, Dax.Metadata.Model model, Dax.ViewVpaExport.Model viewVpa = null, Microsoft.AnalysisServices.Database database = null)
+        public static void ExportVpax(Stream stream, Dax.Metadata.Model model, Dax.ViewVpaExport.Model viewVpa = null, TOM.Database database = null)
         {
             using (ExportVpax exportVpax = new ExportVpax(stream))
             {
@@ -29,7 +28,7 @@ namespace Dax.Vpax.Tools
         /// <summary>
         /// Export to VertiPaq Analyzer (VPAX) file
         /// </summary>
-        public static void ExportVpax(string path, Dax.Metadata.Model model, Dax.ViewVpaExport.Model viewVpa = null, Microsoft.AnalysisServices.Database database = null)
+        public static void ExportVpax(string path, Dax.Metadata.Model model, Dax.ViewVpaExport.Model viewVpa = null, TOM.Database database = null)
         {
             using (ExportVpax exportVpax = new ExportVpax(path))
             {
@@ -37,7 +36,7 @@ namespace Dax.Vpax.Tools
             }
         }
 
-        internal static void InternalExportVpax(ExportVpax exportVpax, Dax.Metadata.Model model, Dax.ViewVpaExport.Model viewVpa = null, Microsoft.AnalysisServices.Database database = null)
+        internal static void InternalExportVpax(ExportVpax exportVpax, Dax.Metadata.Model model, Dax.ViewVpaExport.Model viewVpa = null, TOM.Database database = null)
         {
             if (model != null)
             {
@@ -58,7 +57,7 @@ namespace Dax.Vpax.Tools
         {
             public Dax.Metadata.Model DaxModel;
             public Dax.ViewVpaExport.Model ViewVpa;
-            public Microsoft.AnalysisServices.Database TomDatabase;
+            public TOM.Database TomDatabase;
         }
 
         /// <summary>

--- a/TestDaxModel/Program.cs
+++ b/TestDaxModel/Program.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using System.IO.Packaging;
 using System.IO;
 using Dax.Vpax.Tools;
+using TOM = Microsoft.AnalysisServices.Tabular;
 
 // TODO
 // - Import from DMV 1100 (check for missing attributes?)
@@ -48,7 +49,7 @@ namespace TestDaxModel
             //
             // Get TOM model from the SSAS engine
             //
-            Microsoft.AnalysisServices.Database database = includeTomModel ? Dax.Metadata.Extractor.TomExtractor.GetDatabase(serverName, databaseName) : null;
+            TOM.Database database = includeTomModel ? Dax.Metadata.Extractor.TomExtractor.GetDatabase(serverName, databaseName) : null;
 
             // 
             // Create VertiPaq Analyzer views
@@ -94,7 +95,7 @@ namespace TestDaxModel
             //
             // Get TOM model from the SSAS engine
             //
-            Microsoft.AnalysisServices.Database database = includeTomModel ? Dax.Metadata.Extractor.TomExtractor.GetDatabase(serverName, databaseName) : null;
+            TOM.Database database = includeTomModel ? Dax.Metadata.Extractor.TomExtractor.GetDatabase(serverName, databaseName) : null;
 
             // 
             // Create VertiPaq Analyzer views


### PR DESCRIPTION
- Using TOM.Server instead of Microsoft.AnalysisServices.Server
- Using TOM.Database instead of Microsoft.AnalysisServices.Database

This PR will cause a breaking change in the VpaTools APIs, but from my tests all previously extracted VPAX files still work.