### PR TITLE
Fixed ExtractorLib and DaxModelLib version

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -26,12 +26,12 @@ steps:
     targetType: 'inline'
     script: |
       $versionSuffix = "$(AppVersionSuffix)"
-      if ($versionSuffix -match "\S") { $versionSuffix = "-$versionSuffix" }
+      Write-Host "Set VersionSuffix > '$versionSuffix'"
       Write-Host "##vso[task.setvariable variable=versionSuffix;]$versionSuffix"
-      Write-Host "VersionSuffix $versionSuffix"
-      $packageVersion = "$(semanticVersion)$versionSuffix"
+      $packageVersion = "$(semanticVersion)"
+      if ($versionSuffix -match "\S") { $packageVersion += "-$versionSuffix" }
       if ("$(isReleaseBuild)" -ne "true") { $packageVersion += "-CI-$(Build.BuildNumber)" }
-      Write-Host "Set PackageVersion and BuildNumber to '$packageVersion'"
+      Write-Host "Set PackageVersion > '$packageVersion'"
       Write-Host "##vso[task.setvariable variable=packageVersion;]$packageVersion"
       Write-Host "##vso[build.updatebuildnumber]$packageVersion"
 - task: DownloadSecureFile@1

--- a/src/Dax.Metadata/Model.cs
+++ b/src/Dax.Metadata/Model.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -85,10 +86,11 @@ namespace Dax.Metadata
             // TODO - how to support versioning?
             Version daxModelVersion = new Version(1, 1);
             this.DaxModelVersion = daxModelVersion.ToString();
-            AssemblyName modelAssemblyName = this.GetType().Assembly.GetName();
+            var modelAssembly = this.GetType().Assembly;
+            var modelAssemblyName = modelAssembly.GetName();
+            var modelFileVersionInfo = FileVersionInfo.GetVersionInfo(modelAssembly.Location);
             this.DaxModelLib = modelAssemblyName.Name;
-            Version version = modelAssemblyName.Version;
-            this.DaxModelLibVersion = version.ToString();
+            this.DaxModelLibVersion = modelFileVersionInfo.ProductVersion; // e.g. CI build: 1.2.5-preview2+<git-commit-hash> , RELEASE build: 1.2.5
         }
         public Model(string extractorLib, string extractorLibVersion, string extractorApp = null, string extractorAppVersion = null) : this()
         {

--- a/src/Dax.Model.Extractor/DmvExtractor.cs
+++ b/src/Dax.Model.Extractor/DmvExtractor.cs
@@ -63,12 +63,11 @@ namespace Dax.Metadata.Extractor
                 throw new ExtractorException(connection, databaseName);
             }
 
-            AssemblyName tomExtractorAssemblyName = this.GetType().Assembly.GetName();
-            Version version = tomExtractorAssemblyName.Version;
+            var extractorInfo = Util.GetExtractorInfo(this);
             // Create a DAX model if it is not provided in the constructor arguments
             // This should be outsider the constructor, but we want to make sure the database name is 
             // validated before using other DMVs
-            DaxModel = daxModel ?? new Dax.Metadata.Model(tomExtractorAssemblyName.Name, version.ToString(), extractorApp, extractorVersion);
+            DaxModel = daxModel ?? new Dax.Metadata.Model(extractorInfo.Name, extractorInfo.Version, extractorApp, extractorVersion);
             DaxModel.ServerName = new DaxName(serverName);
             DaxModel.ModelName = new DaxName(databaseName);
             DaxModel.CompatibilityLevel = compatibilityLevel;

--- a/src/Dax.Model.Extractor/TomExtractor.cs
+++ b/src/Dax.Model.Extractor/TomExtractor.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.OleDb;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -17,9 +18,10 @@ namespace Dax.Metadata.Extractor
         private TomExtractor(Tom.Model model, string extractorApp = null, string extractorVersion = null)
         {
             tomModel = model;
-            AssemblyName tomExtractorAssemblyName = GetType().Assembly.GetName();
-            Version version = tomExtractorAssemblyName.Version;
-            DaxModel = new Dax.Metadata.Model(tomExtractorAssemblyName.Name, version.ToString(), extractorApp, extractorVersion);
+
+            var extractorInfo = Util.GetExtractorInfo(this);
+            DaxModel = new Dax.Metadata.Model(extractorInfo.Name, extractorInfo.Version, extractorApp, extractorVersion);
+
             if (tomModel != null) {
                 PopulateModel();
             }

--- a/src/Dax.Model.Extractor/Util.cs
+++ b/src/Dax.Model.Extractor/Util.cs
@@ -1,10 +1,40 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Dax.Metadata.Extractor
 {
-    public static class Util
+    internal class ExtractorInfo
     {
+        public string Name { get; set; }
+        public string Version { get; set; }
+    }
+
+    internal static class Util
+    {
+        public static ExtractorInfo GetExtractorInfo(object extractorInstance)
+        {
+            // AssemblyVersion - contains MAJOR version number only. MINOR,REVISION,BUILDNUMBER numbers are always zero.
+            // e.g.
+            // - RELEASE build: 1.0.0.0
+            // - CI build: 1.0.0.0
+
+            // AssemblyInformationalVersion
+            // e.g.
+            // - RELEASE build: 1.2.5
+            // - CI build: 1.2.5-preview2+<git-commit-hash>
+
+            var assembly = extractorInstance.GetType().Assembly;
+            var assemblyName = assembly.GetName();
+            var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+
+            return new ExtractorInfo
+            {
+                Name = assemblyName.Name,
+                Version = fileVersionInfo.ProductVersion
+            };
+        }
+
         public static IEnumerable<List<T>> SplitList<T>(this List<T> locations, int nSize = 50)
         {
             for (int i = 0; i < locations.Count; i += nSize) {


### PR DESCRIPTION
- Fixed `ExtractorLibVersion` and `DaxModelLibVersion` (SEE notes in `Dax.Metadata.Extractor.Util.GetExtractorInfo`)
- Fixed duplicated hyphen-minus in `AssemblyInformationalVersion`