### PR TITLE
Adding support for columns with GroupBy columns

### DIFF
--- a/src/Dax.Metadata/Column.cs
+++ b/src/Dax.Metadata/Column.cs
@@ -15,6 +15,7 @@ namespace Dax.Metadata
         {
             ColumnHierarchies = new List<ColumnHierarchy>();
             ColumnSegments = new List<ColumnSegment>();
+            GroupByColumns = new List<DaxName>();
         }
 
         public Table Table { get; set; }
@@ -36,6 +37,7 @@ namespace Dax.Metadata
         public bool IsUnique { get; set; }
         public bool KeepUniqueRows { get; set; }
         public DaxName SortByColumnName { get; set; }
+        public List<DaxName> GroupByColumns { get; set; }
         public string State { get; set; }
         public bool IsRowNumber { get; set; }
         public bool IsCalculationGroupAttribute { get; set; }

--- a/src/Dax.Metadata/Dax.Metadata.csproj
+++ b/src/Dax.Metadata/Dax.Metadata.csproj
@@ -50,7 +50,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/Dax.Model.Extractor/Dax.Model.Extractor.csproj
+++ b/src/Dax.Model.Extractor/Dax.Model.Extractor.csproj
@@ -54,12 +54,12 @@
     <PackageReference Include="System.Data.OleDb" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AnalysisServices.retail.amd64" Version="19.39.0" />
-    <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64" Version="19.39.0" />
+    <PackageReference Include="Microsoft.AnalysisServices.retail.amd64" Version="19.46.0" />
+    <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64" Version="19.46.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0-windows'">
-    <PackageReference Include="Microsoft.AnalysisServices.NetCore.retail.amd64" Version="19.39.0" />
-    <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.39.0" />
+    <PackageReference Include="Microsoft.AnalysisServices.NetCore.retail.amd64" Version="19.46.0" />
+    <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.46.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/Dax.Model.Extractor/StatExtractor.cs
+++ b/src/Dax.Model.Extractor/StatExtractor.cs
@@ -228,7 +228,7 @@ USERELATIONSHIP( {EscapeColumnName(rel.FromColumn)}, {EscapeColumnName(rel.ToCol
         {
             return column.GroupByColumns.Count == 0 
                 ? $"DISTINCTCOUNT({EscapeColumnName(column)})"
-                : $"COUNTROWS(DISTINCT(ALL({EscapeColumnName(column)}, { string.Join(",", column.GroupByColumns.Select(c => c.Name.Replace("]","]]")).ToArray<string>()) } ). ))";
+                : $"COUNTROWS(ALLNOBLANKROW({EscapeColumnName(column)}))";
         }
 
         private static string EscapeColumnName(Column column)

--- a/src/Dax.Model.Extractor/TomExtractor.cs
+++ b/src/Dax.Model.Extractor/TomExtractor.cs
@@ -238,7 +238,7 @@ namespace Dax.Metadata.Extractor
             string calculatedColumnExpression =
                 (column.Type == Tom.ColumnType.Calculated) ? (column as Tom.CalculatedColumn)?.Expression : null;
 
-            return new Dax.Metadata.Column(daxTable)
+            Column col = new Dax.Metadata.Column(daxTable)
             {
                 ColumnName = new Dax.Metadata.DaxName(column.Name),
                 DataType = column.DataType.ToString(),
@@ -258,6 +258,13 @@ namespace Dax.Metadata.Extractor
                 FormatString = column.FormatString,
                 Description = new DaxNote(column.Description)
             };
+
+            // if any group by columns exist add them to the list of GroupByColumns
+            if (column.RelatedColumnDetails?.GroupByColumns != null) {
+                col.GroupByColumns.AddRange(column.RelatedColumnDetails?.GroupByColumns.Select(c => new DaxName(c.RelatedColumnDetails.Column.Name)).ToList());
+            }
+
+            return col;
         }
         public static Dax.Metadata.Model GetDaxModel(Tom.Model model, string extractorApp, string extractorVersion)
         {

--- a/src/Dax.ViewVpaExport/Dax.ViewVpaExport.csproj
+++ b/src/Dax.ViewVpaExport/Dax.ViewVpaExport.csproj
@@ -54,7 +54,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/Dax.Vpax/Dax.Vpax.csproj
+++ b/src/Dax.Vpax/Dax.Vpax.csproj
@@ -52,14 +52,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Microsoft.AnalysisServices.retail.amd64" Version="19.39.0" />
+    <PackageReference Include="Microsoft.AnalysisServices.retail.amd64" Version="19.46.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AnalysisServices.NetCore.retail.amd64" Version="19.39.0" />
+    <PackageReference Include="Microsoft.AnalysisServices.NetCore.retail.amd64" Version="19.46.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/Dax.Vpax/ExportVpax.cs
+++ b/src/Dax.Vpax/ExportVpax.cs
@@ -35,6 +35,16 @@ namespace Dax.Vpax
                 tw.Write(TOM.JsonSerializer.SerializeDatabase(database));
                 tw.Close();
             }
+            ExportCompatibilityMode(database);
+        }
+
+        public void ExportCompatibilityMode(TOM.Database database)
+        {
+            Uri uriTom = PackUriHelper.CreatePartUri(new Uri(VpaxFormat.COMPATMODE, UriKind.Relative));
+            using (TextWriter tw = new StreamWriter(this.Package.CreatePart(uriTom, "text/plain", CompressionOption.Maximum).GetStream(), Encoding.UTF8)) {
+                tw.Write(database.CompatibilityMode.ToString());
+                tw.Close();
+            }
         }
 
         public void ExportViewVpa(ViewVpaExport.Model viewVpa)

--- a/src/Dax.Vpax/VpaxFormat.cs
+++ b/src/Dax.Vpax/VpaxFormat.cs
@@ -11,6 +11,7 @@ namespace Dax.Vpax
         public const string DAXMODEL = "DaxModel.json";
         public const string DAXVPAVIEW = "DaxVpaView.json";
         public const string TOMMODEL = "Model.bim";
+        public const string COMPATMODE = "CompatabilityMode.txt";
 
     }
 }

--- a/src/TestDaxModel/Program.cs
+++ b/src/TestDaxModel/Program.cs
@@ -179,8 +179,8 @@ namespace TestDaxModel
             //const string databaseName = "Adventure Works Internet Sales";
             // const string databaseName = "Adventure Works 2012 Tabular";
             // const string databaseName = "EnterpriseBI";
-            const string serverName = "localhost:53393";
-            const string databaseName = "e9dbe0cd-a38d-435f-9400-0786baeff640";
+            const string serverName = "localhost:53406";
+            const string databaseName = "84d819d1-e1b3-4c8a-b9f6-c34ac2d2aba2";
 
             //const string serverName = @"localhost\ctp22";
             //const string databaseName = "Contoso Base";

--- a/src/TestDaxModel/TestDaxModel.csproj
+++ b/src/TestDaxModel/TestDaxModel.csproj
@@ -70,10 +70,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.39.0</Version>
+      <Version>19.46.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/TestDaxWpf/TestDaxWpf.csproj
+++ b/src/TestDaxWpf/TestDaxWpf.csproj
@@ -107,13 +107,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64">
-      <Version>19.39.0</Version>
+      <Version>19.46.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.39.0</Version>
+      <Version>19.46.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/TestPowerBI/TestPowerBI.csproj
+++ b/src/TestPowerBI/TestPowerBI.csproj
@@ -108,7 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.39.0</Version>
+      <Version>19.46.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client">
       <Version>4.42.0</Version>
@@ -123,7 +123,7 @@
       <Version>10.0.22000.196</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>

--- a/src/TestWpfPowerBI/TestWpfPowerBI.csproj
+++ b/src/TestWpfPowerBI/TestWpfPowerBI.csproj
@@ -179,10 +179,10 @@
       <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64">
-      <Version>19.39.0</Version>
+      <Version>19.46.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.39.0</Version>
+      <Version>19.46.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Expression.Drawing">
       <Version>3.0.0</Version>
@@ -197,7 +197,7 @@
       <Version>2.3.23</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.10.0</Version>


### PR DESCRIPTION
Based on this issue from DAX Studio https://github.com/DaxStudio/DaxStudio/issues/879  

I've extended the stats collector to generate correct queries when a column has GroupBy columns set.

I've also extended the vpax file format to generate a CompatibilityMode.txt file since if you save a file with a model.bim from a pbix file with field parameters it will not deserialize the bim file without knowing the compatibility mode, 

But I did also add a retry mechanism for backward compatibility so that if a vpax file has a bim in it the deserialize code will try all the different compatibility modes (PowerBI, AnalysisServices, Excel) if it gets a deserialization error.