### PR TITLE
Update ImportVpax.cs

### DIFF
--- a/src/Dax.Vpax/ImportVpax.cs
+++ b/src/Dax.Vpax/ImportVpax.cs
@@ -78,7 +78,7 @@ namespace Dax.Vpax
             Microsoft.AnalysisServices.CompatibilityMode compatMode = Microsoft.AnalysisServices.CompatibilityMode.Unknown;
             Enum.TryParse(strCompatMode,true , out compatMode );
             string modelBim = ReadPackageContentAsString(VpaxFormat.TOMMODEL);
-            if (modelBim == null) return null;
+            if (string.IsNullOrEmpty(modelBim)) return null;
             var tomDb = TryDeserializeDatabase(modelBim, compatMode);
             return tomDb;
         }


### PR DESCRIPTION
This prevents an error which would be raised from the TOM DeserializeDatabase method, in cases where the vpax file contains an empty .bim file (some old version of VertiPaq Analyzer could cause this).