### PR TITLE
Fixing error when model does not contain dynamic format strings

### DIFF
--- a/src/Dax.Model.Extractor/DmvExtractor.cs
+++ b/src/Dax.Model.Extractor/DmvExtractor.cs
@@ -431,20 +431,9 @@ WHERE [FormatStringDefinitionID] > 0
 
             void ReadFormatStringExpressions()
             {
-                Dictionary<long, string> mapFormatId = new Dictionary<long, string>();
-                using (var cmdId = CreateCommand(QUERY_MEASURESFORMATID)) {
-                    cmdId.CommandTimeout = CommandTimeout;
-                    using (var rdr = cmdId.ExecuteReader()) {
-                        while (rdr.Read()) {
-                            long formatId = rdr.GetInt64(0);
-                            string measureName = rdr.GetValue(1)?.ToString() ?? string.Empty;
-                            if (formatId > 0 && !string.IsNullOrEmpty(measureName)) {
-                                mapFormatId.Add(formatId, measureName);
-                            }
-                        }
-                    }
-                }
+                Dictionary<long,string> mapExpressions = new Dictionary<long, string>();
 
+                // read all format string expressions into a dictionary
                 using var cmd = CreateCommand(QUERY_FORMATSTRINGS);
                 cmd.CommandTimeout = CommandTimeout;
                 using (var rdr = cmd.ExecuteReader()) {
@@ -452,13 +441,31 @@ WHERE [FormatStringDefinitionID] > 0
                         long formatId = rdr.GetInt64(0);
                         string formatStringExpression = rdr.GetValue(1)?.ToString() ?? string.Empty;
                         if (formatId > 0 && !string.IsNullOrEmpty(formatStringExpression)) {
-                            if (mapFormatId.ContainsKey(formatId)) {
-                                string measureName = mapFormatId[formatId];
-                                formatStringExpressions.Add(measureName, formatStringExpression);
+                            mapExpressions.Add(formatId, formatStringExpression);
+                        }
+                    }
+                }
+
+                // if there are no format string expressions exit here
+                if (mapExpressions.Count == 0) return;
+
+                // map the format string expressions to the measure names
+                using (var cmdId = CreateCommand(QUERY_MEASURESFORMATID)) {
+                    cmdId.CommandTimeout = CommandTimeout;
+                    using (var rdr = cmdId.ExecuteReader()) {
+                        while (rdr.Read()) {
+                            long formatId = rdr.GetInt64(0);
+                            string measureName = rdr.GetValue(1)?.ToString() ?? string.Empty;
+                            if (formatId > 0 && !string.IsNullOrEmpty(measureName)) {
+                            
+                                if (mapExpressions.ContainsKey(formatId)) {
+                                    formatStringExpressions.Add(measureName, mapExpressions[formatId]);
+                                }
                             }
                         }
                     }
                 }
+
 
             }
 

--- a/src/Dax.Model.Extractor/DmvExtractor.cs
+++ b/src/Dax.Model.Extractor/DmvExtractor.cs
@@ -436,16 +436,21 @@ WHERE [FormatStringDefinitionID] > 0
                 // read all format string expressions into a dictionary
                 using var cmd = CreateCommand(QUERY_FORMATSTRINGS);
                 cmd.CommandTimeout = CommandTimeout;
-                using (var rdr = cmd.ExecuteReader()) {
-                    while (rdr.Read()) {
-                        long formatId = rdr.GetInt64(0);
-                        string formatStringExpression = rdr.GetValue(1)?.ToString() ?? string.Empty;
-                        if (formatId > 0 && !string.IsNullOrEmpty(formatStringExpression)) {
-                            mapExpressions.Add(formatId, formatStringExpression);
+                try {
+                    using (var rdr = cmd.ExecuteReader()) {
+                        while (rdr.Read()) {
+                            long formatId = rdr.GetInt64(0);
+                            string formatStringExpression = rdr.GetValue(1)?.ToString() ?? string.Empty;
+                            if (formatId > 0 && !string.IsNullOrEmpty(formatStringExpression)) {
+                                mapExpressions.Add(formatId, formatStringExpression);
+                            }
                         }
                     }
                 }
-
+                catch (Exception ex) { 
+                    // we will get an error if the current server does not support dynamic format strings
+                    // we can just swallow this and go on as if no dynamic format strings are defined
+                }
                 // if there are no format string expressions exit here
                 if (mapExpressions.Count == 0) return;
 

--- a/src/TestDaxModel/Program.cs
+++ b/src/TestDaxModel/Program.cs
@@ -20,8 +20,8 @@ namespace TestDaxModel
 
         static void Main()
         {
-            //GenericTest();
-            ConnectionStringTest();
+            GenericTest();
+            //ConnectionStringTest();
             //TestPbiShared_2022();
             //TestPbiShared();
             //TestLocalVpaModel();
@@ -175,12 +175,12 @@ namespace TestDaxModel
             // const string serverName = @"http://localhost:9000/xmla";
             // const string databaseName = "Microsoft_SQLServer_AnalysisServices";
 
-            //const string serverName = @"localhost\tab19";
-            //const string databaseName = "Adventure Works Internet Sales";
+            const string serverName = @"localhost\tab19";
+            const string databaseName = "Adventure Works";
             // const string databaseName = "Adventure Works 2012 Tabular";
             // const string databaseName = "EnterpriseBI";
-            const string serverName = "localhost:53406";
-            const string databaseName = "84d819d1-e1b3-4c8a-b9f6-c34ac2d2aba2";
+            //const string serverName = "localhost:53406";
+            //const string databaseName = "84d819d1-e1b3-4c8a-b9f6-c34ac2d2aba2";
 
             //const string serverName = @"localhost\ctp22";
             //const string databaseName = "Contoso Base";


### PR DESCRIPTION
It appears that the DynamicFormatStringID column in TMSCHEMA_MEASURES is not available UNLESS your model has at least one Dynamic formatstring. So I've swapped the order of the queries so that we check if we can run TMSCHEMA_FORMAT_STRING_DEFINITIONS and if it has any data before trying to map them to measures