### PR TITLE
add from/to column names to VpaRelationship

### DIFF
--- a/src/Dax.ViewModel/VpaRelationship.cs
+++ b/src/Dax.ViewModel/VpaRelationship.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace Dax.ViewModel
@@ -47,5 +48,8 @@ namespace Dax.ViewModel
         /// The ration between dimension and fact table is meaningful only for 1:M relationships
         /// </summary>
         public double OneToManyRatio { get { return (this.Relationship.FromColumn.Table.RowsCount == 0) ? 0 : (double)this.Relationship.ToColumn.ColumnCardinality / (double)this.Relationship.FromColumn.Table.RowsCount; } }
+
+        public string FromColumnName => $"'{Relationship.FromColumn.Table.TableName.Name}'[{Relationship.FromColumn.ColumnName.Name}]";
+        public string ToColumnName => $"'{Relationship.ToColumn.Table.TableName.Name}'[{Relationship.ToColumn.ColumnName.Name}]";
     }
 }

--- a/src/TestDaxModel/Program.cs
+++ b/src/TestDaxModel/Program.cs
@@ -20,8 +20,8 @@ namespace TestDaxModel
 
         static void Main()
         {
-            //GenericTest();
-            ConnectionStringTest();
+            GenericTest();
+            //ConnectionStringTest();
             //TestPbiShared_2022();
             //TestPbiShared();
             //TestLocalVpaModel();
@@ -179,8 +179,8 @@ namespace TestDaxModel
             //const string databaseName = "Adventure Works Internet Sales";
             // const string databaseName = "Adventure Works 2012 Tabular";
             // const string databaseName = "EnterpriseBI";
-            const string serverName = "localhost:53406";
-            const string databaseName = "84d819d1-e1b3-4c8a-b9f6-c34ac2d2aba2";
+            const string serverName = "localhost:49306";
+            const string databaseName = "8829b1b2-732f-4404-802b-d8e0060b0cdd";
 
             //const string serverName = @"localhost\ctp22";
             //const string databaseName = "Contoso Base";
@@ -231,7 +231,11 @@ namespace TestDaxModel
             Console.WriteLine($"   Table Count : {viewVpa.Tables.Count()}");
             Console.WriteLine($"   Column Count: {viewVpa.Columns.Count()}");
             Console.WriteLine($"   Relationships Count: {viewVpa.Relationships.Count()}");
-
+            
+            var vm = new Dax.ViewModel.VpaModel(daxModel);
+            foreach (var r in vm.Relationships) {
+                Console.WriteLine($"From: {r.FromColumnName}  To: {r.ToColumnName} ({r.RelationshipFromToName})");
+            }
         }
 
         static void ConnectionStringTest()

--- a/src/TestDaxModel/TestDaxModel.csproj
+++ b/src/TestDaxModel/TestDaxModel.csproj
@@ -59,6 +59,10 @@
       <Project>{ed728880-f58a-4198-bb71-d24ac4883236}</Project>
       <Name>Dax.Model.Extractor</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Dax.ViewModel\Dax.ViewModel.csproj">
+      <Project>{fcfc0033-ea10-4a50-befe-efd02cf6b35c}</Project>
+      <Name>Dax.ViewModel</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Dax.ViewVpaExport\Dax.ViewVpaExport.csproj">
       <Project>{d8b86b34-102d-4e98-a57e-a4d3fe29af8d}</Project>
       <Name>Dax.ViewVpaExport</Name>


### PR DESCRIPTION
This change will add the from/to column names for relationships to enable client tools to generate a DAX query to list RI Violations.