### PR TITLE
Reducing serialized JSON size

### DIFF
--- a/src/Dax.Vpax/ExportVpax.cs
+++ b/src/Dax.Vpax/ExportVpax.cs
@@ -50,9 +50,12 @@ namespace Dax.Vpax
         public void ExportViewVpa(ViewVpaExport.Model viewVpa)
         {
             Uri uriModelVpa = PackUriHelper.CreatePartUri(new Uri(VpaxFormat.DAXVPAVIEW, UriKind.Relative));
-            using (TextWriter tw = new StreamWriter(this.Package.CreatePart(uriModelVpa, "application/json", CompressionOption.Maximum).GetStream(), Encoding.UTF8))
-            {
-                tw.Write(JsonConvert.SerializeObject(viewVpa, Formatting.Indented));
+            using (TextWriter tw = new StreamWriter(this.Package.CreatePart(uriModelVpa, "application/json", CompressionOption.Maximum).GetStream(), Encoding.UTF8)) {
+                var value = JsonConvert.SerializeObject(viewVpa, Formatting.None, new JsonSerializerSettings
+                {
+                    DefaultValueHandling = DefaultValueHandling.Ignore,
+                });
+                tw.Write(value);
                 tw.Close();
             }
         }
@@ -60,24 +63,18 @@ namespace Dax.Vpax
         public void ExportModel(Metadata.Model model)
         {
             Uri uriModel = PackUriHelper.CreatePartUri(new Uri(VpaxFormat.DAXMODEL, UriKind.Relative));
-            using (TextWriter tw = new StreamWriter(this.Package.CreatePart(uriModel, "application/json", CompressionOption.Maximum).GetStream(), Encoding.UTF8))
-            {
-                tw.Write(
-                    JsonConvert.SerializeObject(
-                        model,
-                        Formatting.Indented,
-                        new JsonSerializerSettings
-                        {
-                            PreserveReferencesHandling = PreserveReferencesHandling.All,
-                            ReferenceLoopHandling = ReferenceLoopHandling.Serialize
-                        }
-                    )
-                );
+            using (TextWriter tw = new StreamWriter(this.Package.CreatePart(uriModel, "application/json", CompressionOption.Maximum).GetStream(), Encoding.UTF8)) {
+                var value = JsonConvert.SerializeObject(model, Formatting.None, new JsonSerializerSettings
+                {
+                    DefaultValueHandling = DefaultValueHandling.Ignore,
+                    PreserveReferencesHandling = PreserveReferencesHandling.All,
+                    ReferenceLoopHandling = ReferenceLoopHandling.Serialize
+                });
+                tw.Write(value);
                 tw.Close();
             }
         }
 
-       
         #region IDisposable Support
         private bool disposedValue = false; // To detect redundant calls
 

--- a/src/Dax.Vpax/ExportVpax.cs
+++ b/src/Dax.Vpax/ExportVpax.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Linq;
 using System.Text;
 using System.IO;
 using System.IO.Packaging;
 using Newtonsoft.Json;
 using TOM = Microsoft.AnalysisServices.Tabular;
+using Dax.Vpax.Json;
 
 namespace Dax.Vpax
 {
@@ -53,6 +53,7 @@ namespace Dax.Vpax
             using (TextWriter tw = new StreamWriter(this.Package.CreatePart(uriModelVpa, "application/json", CompressionOption.Maximum).GetStream(), Encoding.UTF8)) {
                 var value = JsonConvert.SerializeObject(viewVpa, Formatting.None, new JsonSerializerSettings
                 {
+                    ContractResolver = ShouldSerializeContractResolver.Instance,
                     DefaultValueHandling = DefaultValueHandling.Ignore,
                 });
                 tw.Write(value);
@@ -66,6 +67,7 @@ namespace Dax.Vpax
             using (TextWriter tw = new StreamWriter(this.Package.CreatePart(uriModel, "application/json", CompressionOption.Maximum).GetStream(), Encoding.UTF8)) {
                 var value = JsonConvert.SerializeObject(model, Formatting.None, new JsonSerializerSettings
                 {
+                    ContractResolver = ShouldSerializeContractResolver.Instance,
                     DefaultValueHandling = DefaultValueHandling.Ignore,
                     PreserveReferencesHandling = PreserveReferencesHandling.All,
                     ReferenceLoopHandling = ReferenceLoopHandling.Serialize

--- a/src/Dax.Vpax/Json/ShouldSerializeContractResolver.cs
+++ b/src/Dax.Vpax/Json/ShouldSerializeContractResolver.cs
@@ -1,0 +1,44 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System.Collections;
+using System.Reflection;
+
+namespace Dax.Vpax.Json
+{
+    internal class ShouldSerializeContractResolver : DefaultContractResolver
+    {
+        internal static readonly ShouldSerializeContractResolver Instance = new ShouldSerializeContractResolver();
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+
+            //if (property.PropertyType == typeof(Metadata.DaxNote)) {
+            //    property.ShouldSerialize = (instance) =>
+            //    {
+            //        var daxNode = (Metadata.DaxNote)instance.GetType().GetProperty(property.PropertyName).GetValue(instance);
+            //        return daxNode.Note?.Length > 0;
+            //    };
+            //}
+
+            // Don't serialize empty JSON arrays
+            if (typeof(IList).IsAssignableFrom(property.PropertyType)) {
+                property.ShouldSerialize = (instance) =>
+                {
+                    var list = (IList)instance.GetType().GetProperty(property.PropertyName).GetValue(instance);
+                    return list.Count > 0;
+                };
+            }
+
+            if (property.DeclaringType == typeof(Metadata.Column)) {
+                switch (property.PropertyName) {
+                    case nameof(Metadata.Column.SortByColumnName):
+                        property.ShouldSerialize = (instance) => ((Metadata.Column)instance).SortByColumnName?.Name != null;
+                        break;
+                }
+            }
+
+            return property;
+        }
+    }
+}


### PR DESCRIPTION
- Use JSON `Formatting.None` and `DefaultValueHandling.Ignore`
- Add `ShouldSerializeContractResolver` to avoid empty array serialization