### PR TITLE
Add TomConnection to allow use of an existing connection

### DIFF
--- a/src/Dax.Model.Extractor/Data/IDbConnectionExtensions.cs
+++ b/src/Dax.Model.Extractor/Data/IDbConnectionExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Dax.Metadata.Extractor;
+using Microsoft.AnalysisServices.AdomdClient;
+using System.Data;
+using System.Data.OleDb;
+
+namespace Dax.Model.Extractor.Data
+{
+    internal static class IDbConnectionExtensions
+    {
+        public static IDbCommand CreateCommand(this IDbConnection connection, string commandText)
+        {
+            return connection switch
+            {
+                AdomdConnection adomdConnection => new AdomdCommand(commandText, adomdConnection),
+                OleDbConnection oledbConnection => new OleDbCommand(commandText, oledbConnection),
+                TomConnection tomConnection => new TomCommand(commandText, tomConnection),
+                _ => throw new ExtractorException(connection),
+            };
+        }
+    }
+}

--- a/src/Dax.Model.Extractor/Data/TomCommand.cs
+++ b/src/Dax.Model.Extractor/Data/TomCommand.cs
@@ -1,0 +1,111 @@
+﻿using Microsoft.AnalysisServices;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Dax.Model.Extractor.Data
+{
+    internal class TomCommand : IDbCommand, IDisposable
+    {
+        private readonly TomConnection _connection;
+        private AmoDataReader _reader;
+
+        public TomCommand(TomConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public TomCommand(string commandText, TomConnection connection)
+            : this(connection)
+        {
+            CommandText = commandText;
+        }
+
+        public string CommandText { get; set; }
+
+        public int CommandTimeout { get; set; }
+
+        public IDbConnection Connection { get; set; }
+
+        public IDataReader ExecuteReader()
+        {
+            var command = new XElement("Statement", CommandText).ToString();
+            var properties = string.IsNullOrEmpty(_connection.Database) ? null : new Dictionary<string, string> { { "Catalog", _connection.Database } };
+
+            _reader = _connection.Server.ExecuteReader(command, out var results, properties);
+
+            if (results != null && results.ContainsErrors)
+                throw new AmoException(GetMessages(results));
+
+            return _reader;
+
+            static string GetMessages(XmlaResultCollection xmlaResults)
+            {
+                var messages = xmlaResults.OfType<XmlaResult>().SelectMany((r) => r.Messages.OfType<XmlaMessage>()).Select((r) => r.Description).ToArray();
+                return string.Join(Environment.NewLine, messages);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_reader != null && !_reader.IsClosed) {
+                _reader.Close();
+            }
+        }
+
+        #region Methods and properties that throw a NotImplementedException
+
+        public CommandType CommandType {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public IDataParameterCollection Parameters {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IDbTransaction Transaction {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public UpdateRowSource UpdatedRowSource {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public void Cancel()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDbDataParameter CreateParameter()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int ExecuteNonQuery()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDataReader ExecuteReader(CommandBehavior behavior)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object ExecuteScalar()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Prepare()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+}

--- a/src/Dax.Model.Extractor/Data/TomConnection.cs
+++ b/src/Dax.Model.Extractor/Data/TomConnection.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Data;
+using Tom = Microsoft.AnalysisServices.Tabular;
+
+namespace Dax.Model.Extractor.Data
+{
+    public class TomConnection : IDbConnection, IDisposable
+    {
+        public TomConnection(Tom.Server server, string database)
+        {
+            Server = server;
+            Database = database;
+        }
+
+        public Tom.Server Server { get; }
+
+        public string Database { get; }
+
+        public IDbCommand CreateCommand()
+        {
+            return new TomCommand(this);
+        }
+
+        public void Open()
+        {
+        }
+
+        public void Close()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        #region Methods and properties that throw a NotImplementedException
+
+        public string ConnectionString {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        public int ConnectionTimeout {
+            get { throw new NotImplementedException(); }
+        }
+
+        public ConnectionState State {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IDbTransaction BeginTransaction()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDbTransaction BeginTransaction(IsolationLevel il)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ChangeDatabase(string databaseName)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+}

--- a/src/Dax.Model.Extractor/DmvExtractor.cs
+++ b/src/Dax.Model.Extractor/DmvExtractor.cs
@@ -1,18 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using System.Data.OleDb;
-using Tom = Microsoft.AnalysisServices.Tabular;
+﻿using Dax.Model.Extractor.Data;
 using Microsoft.AnalysisServices.AdomdClient;
+using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
+using System.Linq;
+using Tom = Microsoft.AnalysisServices.Tabular;
 
 namespace Dax.Metadata.Extractor
 {
-    
+
     public class ExtractorException : Exception
     {
         public IDbConnection Connection { get; private set; }
@@ -31,25 +28,13 @@ namespace Dax.Metadata.Extractor
     {
         public int CommandTimeout { get; set; } = 0;
 
-        // protected AdomdConnection Connection { get; private set; }
         protected IDbConnection Connection { get; private set; }
 
         public Dax.Metadata.Model DaxModel { get; private set; }
 
         protected IDbCommand CreateCommand(string commandText)
         {
-            if (Connection is AdomdConnection)
-            {
-                return new AdomdCommand(commandText, Connection as AdomdConnection);
-            }
-            else if (Connection is OleDbConnection)
-            {
-                return new OleDbCommand(commandText, Connection as OleDbConnection);
-            }
-            else
-            {
-                throw new ExtractorException(Connection);
-            }
+            return Connection.CreateCommand(commandText);
         }
 
         public DmvExtractor(Dax.Metadata.Model daxModel, IDbConnection connection, string serverName, string databaseName, string extractorApp, string extractorVersion)

--- a/src/Dax.Model.Extractor/StatExtractor.cs
+++ b/src/Dax.Model.Extractor/StatExtractor.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Data.OleDb;
-using Microsoft.AnalysisServices.AdomdClient;
-using System.Reflection;
+﻿using Dax.Model.Extractor.Data;
+using System;
 using System.Data;
+using System.Linq;
 
 namespace Dax.Metadata.Extractor
 {
@@ -23,18 +18,7 @@ namespace Dax.Metadata.Extractor
 
         protected IDbCommand CreateCommand(string commandText)
         {
-            if (Connection is AdomdConnection)
-            {
-                return new AdomdCommand(commandText, Connection as AdomdConnection);
-            }
-            else if (Connection is OleDbConnection)
-            {
-                return new OleDbCommand(commandText, Connection as OleDbConnection);
-            }
-            else
-            {
-                throw new ExtractorException(Connection);
-            }
+            return Connection.CreateCommand(commandText);
         }
 
         public static void UpdateStatisticsModel(Dax.Metadata.Model daxModel, IDbConnection connection, int sampleRows = 0, bool analyzeDirectQuery = false )

--- a/utils/TestDaxModel/Program.cs
+++ b/utils/TestDaxModel/Program.cs
@@ -21,12 +21,26 @@ namespace TestDaxModel
         static void Main()
         {
             GenericTest();
+            //TestTomConnection();
             //ConnectionStringTest();
             //TestPbiShared_2022();
             //TestPbiShared();
             //TestLocalVpaModel();
             //TestExport();
             //TestExportStream();
+        }
+
+        static void TestTomConnection()
+        {
+            const string serverName = "localhost:61422";
+            const string databaseName = "4fcf623e-9bfe-42ff-bdf6-c5b7bd02e7a4";
+
+            var server = new TOM.Server();
+            server.Connect($"Provider=MSOLAP;Data Source={serverName};Initial Catalog={databaseName};");
+            var daxModel = Dax.Metadata.Extractor.TomExtractor.GetDaxModel(server.Databases[databaseName].Model, "TestDaxModel", "0.2");
+            var tomConnection = new Dax.Model.Extractor.Data.TomConnection(server, databaseName);
+            Dax.Metadata.Extractor.DmvExtractor.PopulateFromDmv(daxModel, tomConnection, serverName, databaseName, "TestDaxModel", "0.2");
+            Dax.Metadata.Extractor.StatExtractor.UpdateStatisticsModel(daxModel, tomConnection, sampleRows: 100);
         }
 
         static void TestExportStream()


### PR DESCRIPTION
`TomConnection` allows use an existing connection instead of letting VertiPaq Analyzer open its own connections to AS