### PR TITLE
Fix NullReferenceException on ViewVpa export

### DIFF
--- a/src/Dax.ViewVpaExport/Column.cs
+++ b/src/Dax.ViewVpaExport/Column.cs
@@ -41,7 +41,7 @@ namespace Dax.ViewVpaExport
         public string ColumnType { get { return this._Column.ColumnType; } }
         public bool IsHidden { get { return this._Column.IsHidden; } }
         public string Encoding { get { return this._Column.Encoding; } }
-        public string ColumnExpression { get { return this._Column.ColumnExpression?.Expression?.ToString(); } }
+        public string ColumnExpression { get { return this._Column.ColumnExpression?.Expression; } }
         public string DisplayFolder { get { return this._Column.DisplayFolder?.Note; } }
         public string Description { get { return this._Column.Description?.Note; } }
         public string FormatString { get { return this._Column.FormatString;  } }
@@ -52,7 +52,7 @@ namespace Dax.ViewVpaExport
         public bool IsNullable { get { return this._Column.IsNullable; } }
         public bool IsUnique { get { return this._Column.IsUnique; } }
         public bool KeepUniqueRows { get { return this._Column.KeepUniqueRows; } }
-        public string SortByColumnName { get { return this._Column.SortByColumnName?.ToString(); } }
+        public string SortByColumnName { get { return this._Column.SortByColumnName?.Name; } }
         public string State { get { return this._Column.State; } }
         public bool IsRowNumber { get { return this._Column.IsRowNumber; } }
         public bool IsReferenced { get { return this._Column.IsReferenced; } }

--- a/src/Dax.ViewVpaExport/ColumnSegment.cs
+++ b/src/Dax.ViewVpaExport/ColumnSegment.cs
@@ -22,7 +22,7 @@ namespace Dax.ViewVpaExport
                 return Column.GetFullColumnName(this._ColumnSegment.Column);
             }
         }
-        public string PartitionName => this._ColumnSegment.Partition.PartitionName.ToString();
+        public string PartitionName => this._ColumnSegment.Partition.PartitionName.Name;
         public string PartitionState => this._ColumnSegment.Partition.State?.ToString();
         public string PartitionType => this._ColumnSegment.Partition.Type?.ToString();
         public string PartitionMode => this._ColumnSegment.Partition.Type?.ToString();

--- a/src/Dax.ViewVpaExport/Measure.cs
+++ b/src/Dax.ViewVpaExport/Measure.cs
@@ -24,8 +24,8 @@ namespace Dax.ViewVpaExport
 
         public string MeasureExpression { get { return this._Measure.MeasureExpression?.Expression; } }
         public string FormatStringExpression { get { return this._Measure.FormatStringExpression?.Expression; } }  
-        public string DisplayFolder { get { return this._Measure.DisplayFolder.ToString(); } }
-        public string Description { get { return this._Measure.Description.ToString(); } }
+        public string DisplayFolder { get { return this._Measure.DisplayFolder?.Note; } }
+        public string Description { get { return this._Measure.Description?.Note; } }
         public bool IsHidden { get { return this._Measure.IsHidden; } }
         public string DataType { get { return this._Measure.DataType; } }
         public string DetailRowsExpression { get { return this._Measure.DetailRowsExpression?.Expression; } }

--- a/src/Dax.ViewVpaExport/Table.cs
+++ b/src/Dax.ViewVpaExport/Table.cs
@@ -23,7 +23,7 @@ namespace Dax.ViewVpaExport
         public bool IsLocalDateTable => this._Table.IsLocalDateTable;
         public bool IsTemplateDateTable => this._Table.IsTemplateDateTable;
 
-        public string Description { get { return this._Table.Description.ToString(); } }
+        public string Description { get { return this._Table.Description?.Note; } }
 
         public long ColumnsSize { get { return this._Table.ColumnsTotalSize; } }
 

--- a/utils/TestDaxModel/TestDaxModel.csproj
+++ b/utils/TestDaxModel/TestDaxModel.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.65.7.2</Version>
+      <Version>19.69.2.2</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/utils/TestDaxWpf/TestDaxWpf.csproj
+++ b/utils/TestDaxWpf/TestDaxWpf.csproj
@@ -93,10 +93,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64">
-      <Version>19.65.7.2</Version>
+      <Version>19.69.2.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.65.7.2</Version>
+      <Version>19.69.2.2</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/utils/TestPowerBI/TestPowerBI.csproj
+++ b/utils/TestPowerBI/TestPowerBI.csproj
@@ -90,7 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.65.7.2</Version>
+      <Version>19.69.2.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client">
       <Version>4.43.0</Version>

--- a/utils/TestWpfPowerBI/TestWpfPowerBI.csproj
+++ b/utils/TestWpfPowerBI/TestWpfPowerBI.csproj
@@ -157,10 +157,10 @@
       <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64">
-      <Version>19.65.7.2</Version>
+      <Version>19.69.2.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.65.7.2</Version>
+      <Version>19.69.2.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Expression.Drawing">
       <Version>3.0.0</Version>


### PR DESCRIPTION
Fix a `NullReferenceException` error that occurs when when the `ViewVpa` model is extracted from a PowerPivot data model .

Other changes:
- Remove unnecessary `ToString()`
- Replace `ToString` with `Name` where a non-null `PartitionName` is expected
- TOM dependency version alignment in utils projects