### PR TITLE
Handling AmoException when populating references

### DIFF
--- a/src/Dax.Model.Extractor/DmvExtractor.cs
+++ b/src/Dax.Model.Extractor/DmvExtractor.cs
@@ -1,4 +1,5 @@
 ﻿using Dax.Model.Extractor.Data;
+using Microsoft.AnalysisServices;
 using Microsoft.AnalysisServices.AdomdClient;
 using System;
 using System.Collections.Generic;
@@ -1099,6 +1100,10 @@ FROM $SYSTEM.DISCOVER_CALC_DEPENDENCY
             catch (AdomdErrorResponseException ex)
             {
                 // We ignore errors accessing this DMV
+                Debug.WriteLine($"Ignored error in DISCOVER_CALC_DEPENDENCY: {ex.Message}");
+            }
+            catch (AmoException ex)
+            {
                 Debug.WriteLine($"Ignored error in DISCOVER_CALC_DEPENDENCY: {ex.Message}");
             }
         }


### PR DESCRIPTION
If the DmvExtractor is invoked using a TomConnection, rather than an AdomdConnection, any exceptions raised will be AmoExceptions, rather than AdomdErrorResponseExceptions, so they should be handled the same way. Specifically, the PopulateReferences method is known to fail in some cases, but when the AmoException isn't catched here, the whole DmvExtraction fails, rather than just the references stats.