### PR TITLE
Adding Directlake options for collecting metrics

### DIFF
--- a/src/Dax.Metadata/Column.cs
+++ b/src/Dax.Metadata/Column.cs
@@ -111,5 +111,8 @@ namespace Dax.Metadata
                 cs.Column = this;
             }
         }
+
+        [JsonIgnore]
+        public bool IsResident => ColumnSegments.Any(s => s.IsResident??true);  // if IsResident is null this is an import model
     }
 }

--- a/src/Dax.Metadata/Partition.cs
+++ b/src/Dax.Metadata/Partition.cs
@@ -39,7 +39,8 @@ namespace Dax.Metadata
             DirectQuery = 1,
             Default = 2,
             Push = 3,
-            Dual = 4
+            Dual = 4,
+            DirectLake = 5
         }
 
         public Partition(Table table)

--- a/src/Dax.Metadata/Table.cs
+++ b/src/Dax.Metadata/Table.cs
@@ -54,9 +54,21 @@ namespace Dax.Metadata
         public bool HasDirectQueryPartitions { 
             get {
                 foreach (var partition in Partitions) {
-                    if (partition.Mode == Partition.PartitionMode.DirectQuery || partition.Mode == Partition.PartitionMode.Dual) 
+                    if (partition.Mode == Partition.PartitionMode.DirectQuery || partition.Mode == Partition.PartitionMode.Dual ) 
                         return true;
-                    if (partition.Mode == Partition.PartitionMode.Default && (this.Model.DefaultMode == Partition.PartitionMode.DirectQuery || this.Model.DefaultMode == Partition.PartitionMode.Dual)) 
+                    if (partition.Mode == Partition.PartitionMode.Default && (this.Model.DefaultMode == Partition.PartitionMode.DirectQuery || this.Model.DefaultMode == Partition.PartitionMode.Dual )) 
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        public bool HasDirectLakePartitions {
+            get {
+                foreach (var partition in Partitions) {
+                    if ( partition.Mode == Partition.PartitionMode.DirectLake)
+                        return true;
+                    if (partition.Mode == Partition.PartitionMode.Default && (this.Model.DefaultMode == Partition.PartitionMode.DirectLake))
                         return true;
                 }
                 return false;

--- a/src/Dax.Model.Extractor/DmvExtractor.cs
+++ b/src/Dax.Model.Extractor/DmvExtractor.cs
@@ -41,7 +41,9 @@ namespace Dax.Metadata.Extractor
         public DmvExtractor(Dax.Metadata.Model daxModel, IDbConnection connection, string serverName, string databaseName, string extractorApp, string extractorVersion)
         {
             Connection = connection;
-            Connection.Open();
+
+            // if the connection is not already open, then open it
+            if (Connection.State != ConnectionState.Open) Connection.Open();
 
             // Validate databaseName
             var compatibilityLevel = daxModel.CompatibilityLevel; // assume the default obtained by TOM if any, or unknown/0 otherwise

--- a/src/Dax.Model.Extractor/StatExtractor.cs
+++ b/src/Dax.Model.Extractor/StatExtractor.cs
@@ -40,7 +40,7 @@ namespace Dax.Metadata.Extractor
             // only get relationship stats if the relationship has an ID
             var relationshipList = DaxModel.Relationships.Where(r => r.Dmv1200RelationshipId != 0)
                 .Where(rel =>
-                    // we are analyzing DQ and both columns are in a table with DQ partitions
+                    // we are analyzing DQ and either column is in a table with DQ partitions
                     (analyzeDirectQuery && ((rel.FromColumn.Table.HasDirectQueryPartitions) || (rel.ToColumn.Table.HasDirectQueryPartitions)))
 
                     // or we are analyzing DL and either column is in a table with DL partitions

--- a/src/Dax.Model.Extractor/Util.cs
+++ b/src/Dax.Model.Extractor/Util.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using Tom = Microsoft.AnalysisServices;
 
@@ -9,6 +10,17 @@ namespace Dax.Metadata.Extractor
     {
         public string Name { get; set; }
         public string Version { get; set; }
+    }
+
+    public enum DirectLakeExtractionMode
+    {
+
+        [Description("Only does a detailed scan of columns that are already in memory")]
+        ResidentOnly,
+        [Description("Only does a detailed scan of columns referenced by measures or relationships")]
+        Referenced,
+        [Description("Does a detailed scan of all columns forcing them to be paged into memory")]
+        Full
     }
 
     internal static class Util

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,10 +6,10 @@
     <MicrosoftAnalysisServicesVersion>19.76.0</MicrosoftAnalysisServicesVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AnalysisServices.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
-    <PackageVersion Include="Microsoft.AnalysisServices.NetCore.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
-    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
-    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
+    <PackageVersion Include="Microsoft.AnalysisServices.retail.amd64" Version="19.77.0" />
+    <PackageVersion Include="Microsoft.AnalysisServices.NetCore.retail.amd64" Version="19.77.0" />
+    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64" Version="19.77.0" />
+    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.77.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Data.OleDb" Version="6.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,10 +6,10 @@
     <MicrosoftAnalysisServicesVersion>19.77.0</MicrosoftAnalysisServicesVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AnalysisServices.retail.amd64" Version="19.77.0" />
-    <PackageVersion Include="Microsoft.AnalysisServices.NetCore.retail.amd64" Version="19.77.0" />
-    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64" Version="19.77.0" />
-    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.77.0" />
+    <PackageVersion Include="Microsoft.AnalysisServices.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
+    <PackageVersion Include="Microsoft.AnalysisServices.NetCore.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
+    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
+    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Data.OleDb" Version="6.0.0" />

--- a/utils/TestDaxModel/Program.cs
+++ b/utils/TestDaxModel/Program.cs
@@ -9,6 +9,7 @@ using System.IO.Packaging;
 using System.IO;
 using Dax.Vpax.Tools;
 using TOM = Microsoft.AnalysisServices.Tabular;
+using Dax.Metadata.Extractor;
 
 // TODO
 // - Import from DMV 1100 (check for missing attributes?)
@@ -189,13 +190,16 @@ namespace TestDaxModel
             // const string serverName = @"http://localhost:9000/xmla";
             // const string databaseName = "Microsoft_SQLServer_AnalysisServices";
 
-            const string serverName = @"localhost\tab19";
-            const string databaseName = "Adventure Works";
+            //const string serverName = @"localhost\tab19";
+            //const string databaseName = "Adventure Works";
             // const string databaseName = "Adventure Works 2012 Tabular";
             // const string databaseName = "EnterpriseBI";
-            //const string serverName = "localhost:53406";
-            //const string databaseName = "84d819d1-e1b3-4c8a-b9f6-c34ac2d2aba2";
+            //const string serverName = "powerbi://api.powerbi.com/v1.0/myorg/FabricCAT%20BigDemoDB";
+            //const string databaseName = "QuerySpeedTesting";
 
+            const string serverName = "powerbi://api.powerbi.com/v1.0/myorg/dgosbell%20LH%20Tutorial";
+            const string databaseName = "wwilakehouse custom";
+            DirectLakeExtractionMode directLakeExtractionMode = DirectLakeExtractionMode.Full;
             //const string serverName = @"localhost\ctp22";
             //const string databaseName = "Contoso Base";
 
@@ -203,7 +207,7 @@ namespace TestDaxModel
 
             Console.WriteLine("Getting model {0}:{1}", serverName, databaseName);
             var database = Dax.Metadata.Extractor.TomExtractor.GetDatabase(serverName, databaseName);
-            var daxModel = Dax.Metadata.Extractor.TomExtractor.GetDaxModel(serverName, databaseName, "TestDaxModel", "0.2", true, 10, analyzeDirectQuery:true);
+            var daxModel = Dax.Metadata.Extractor.TomExtractor.GetDaxModel(serverName, databaseName, "TestDaxModel", "0.2", true, 10, analyzeDirectQuery:true, analyzeDirectLake: directLakeExtractionMode);
             Console.WriteLine(database.CompatibilityMode);
             //DumpReferencedColumns(daxModel);
             //DumpReferencedMeasures(daxModel);
@@ -226,7 +230,7 @@ namespace TestDaxModel
             Console.WriteLine($"   Table Count : {viewVpa.Tables.Count()}");
             Console.WriteLine($"   Column Count: {viewVpa.Columns.Count()}");
             Console.WriteLine($"   Relationships Count: {viewVpa.Relationships.Count()}");
-            string filename = pathOutput + databaseName + ".vpax";
+            string filename = $"{pathOutput}{databaseName}-{directLakeExtractionMode.ToString()}.vpax";
             Console.WriteLine("Saving {0}...", filename);
 
             // Save VPAX file

--- a/utils/TestDaxModel/TestDaxModel.csproj
+++ b/utils/TestDaxModel/TestDaxModel.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.69.2.2</Version>
+      <Version>19.77.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/utils/TestDaxWpf/MainWindow.xaml.cs
+++ b/utils/TestDaxWpf/MainWindow.xaml.cs
@@ -43,7 +43,7 @@ namespace TestDaxWpf
             */
 
             // Extract Dax.Model from SSAS connection
-            var m = TestDaxModelHelper.GetDaxModel(@"localhost\tab17", "AdventureWorks");
+            var m = TestDaxModelHelper.GetDaxModel(@"localhost\tab19", "Adventure Works");
 
             var vm = new Dax.ViewModel.VpaModel(m);
             treeviewTables.DataContext = vm;

--- a/utils/TestDaxWpf/TestDaxWpf.csproj
+++ b/utils/TestDaxWpf/TestDaxWpf.csproj
@@ -93,10 +93,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64">
-      <Version>19.69.2.2</Version>
+      <Version>19.77.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.69.2.2</Version>
+      <Version>19.77.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/utils/TestPowerBI/TestPowerBI.csproj
+++ b/utils/TestPowerBI/TestPowerBI.csproj
@@ -90,7 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.69.2.2</Version>
+      <Version>19.77.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client">
       <Version>4.43.0</Version>

--- a/utils/TestWpfPowerBI/MainWindow.xaml.cs
+++ b/utils/TestWpfPowerBI/MainWindow.xaml.cs
@@ -111,16 +111,16 @@ namespace TestWpfPowerBI
                     {
                         if (g.Group.IsOnDedicatedCapacity.Value == true) { 
                             DisplayStatus($"Loading datasets for group {g.Name}...");
-                            g.Group.Datasets = new BindableCollection<Dataset>(
-                                from d in PowerBI_Tools.GetDatasets(g.Group)
+                            g.Datasets = new BindableCollection<TreeViewPbiItem>(
+                                from d in PowerBI_Tools.GetDatasets(g.Group.Id)
                                 orderby d.Name
-                                select d
+                                select new TreeViewPbiDataset(d , null, null)
                             );
                         }
                     }
                     groups =
                         from g in groups
-                        where g.Group.Datasets?.Count > 0
+                        where g.Datasets?.Count > 0
                         orderby g.Name
                         select g;
                     DisplayStatus($"Loaded {groups.Count()} groups.", 3000);
@@ -191,10 +191,10 @@ namespace TestWpfPowerBI
                 await Task.Run(() =>
                 {
                     DisplayStatus($"Loading datasets for group {selectedGroup.Name}...");
-                    selectedGroup.Datasets = new BindableCollection<Dataset>(
-                            from d in PowerBI_Tools.GetDatasets(selectedGroup)
+                    selectedGroup.Datasets = new BindableCollection<TreeViewPbiItem>(
+                            from d in PowerBI_Tools.GetDatasets(selectedGroup.Group.Id)
                             orderby d.Name
-                            select d
+                            select new TreeViewPbiDataset(d, null, null)
                         );
                     DisplayStatus();
                 });
@@ -290,7 +290,7 @@ namespace TestWpfPowerBI
         {
             foreach ( var g in PbiMetadataTreeBinding.PbiGroups)
             {
-                foreach (var d in g.Group.Datasets)
+                foreach (var d in g.Datasets)
                 {
                     if (d.Name == datasetName) 
                         return g.Group;
@@ -352,16 +352,16 @@ namespace TestWpfPowerBI
             if (expandedGroup == null) return;
             Log.Information($"Group:{expandedGroup.Name}");
 
-            var _group = expandedGroup.Group;
+            var _group = expandedGroup;
             if (_group.Datasets == null)
             {
                 await Task.Run(() =>
                 {
                     DisplayStatus($"Loading datasets for group {_group.Name}...");
-                    _group.Datasets = new BindableCollection<Dataset>(
-                            from d in PowerBI_Tools.GetDatasets(_group)
+                    _group.Datasets = new BindableCollection<TreeViewPbiItem>(
+                            from d in PowerBI_Tools.GetDatasets(_group.Group.Id)
                             orderby d.Name
-                            select d
+                            select new TreeViewPbiDataset(d,null,null)
                         );
 
                     // Enforce refresh? Not working...

--- a/utils/TestWpfPowerBI/Model/TreeViewPbiItems.cs
+++ b/utils/TestWpfPowerBI/Model/TreeViewPbiItems.cs
@@ -8,7 +8,7 @@ using Microsoft.PowerBI.Api.Models;
 
 namespace TestWpfPowerBI.Model
 {
-    public delegate IEnumerable<TreeViewPbiItem> GetChildrenDelegate(IEventAggregator eventAggregator);
+    public delegate IEnumerable<TreeViewPbiItem> GetChildrenDelegate(TreeViewPbiItem item, IEventAggregator eventAggregator);
 
     public abstract class TreeViewPbiItem : PropertyChangedBase
     {
@@ -22,13 +22,14 @@ namespace TestWpfPowerBI.Model
         }
 
         public abstract string Name { get; }
-
+        public abstract Guid Id { get; }
+        private IEnumerable<TreeViewPbiItem> _children;
         // private IEnumerable<TreeViewPbiItem> _children;
         public IEnumerable<TreeViewPbiItem> Children {
             get {
-                IEnumerable<TreeViewPbiItem> _children = null;
+                //IEnumerable<TreeViewPbiItem> _children = null;
                 if (_children == null && _getChildren != null)
-                { _children = _getChildren.Invoke(_eventAggregator); }
+                { _children = _getChildren.Invoke(this, _eventAggregator); }
                 return _children;
             }
         }
@@ -44,9 +45,11 @@ namespace TestWpfPowerBI.Model
 
         public override string Name { get { return Group.Name; } }
 
+        public override Guid Id => Group.Id;
+
         public Group Group { get; set; }
 
-        // public IList<TreeViewPbiItem> Datasets { get { GetChildrenDelegate()}
+        public IList<TreeViewPbiItem> Datasets { get; set; }
     }
 
     public class TreeViewPbiDataset : TreeViewPbiItem
@@ -58,7 +61,7 @@ namespace TestWpfPowerBI.Model
         }
 
         public override string Name { get { return Dataset.Name; } }
-
+        public override Guid Id => Guid.Parse(Dataset.Id);
         public Dataset Dataset { get; set; }
     }
 
@@ -71,6 +74,8 @@ namespace TestWpfPowerBI.Model
         }
 
         public override string Name { get; }
+
+        public override Guid Id => Guid.Empty;
 
         public Dataset Dataset { get; set; }
     }

--- a/utils/TestWpfPowerBI/PowerBI/MetadataTools.cs
+++ b/utils/TestWpfPowerBI/PowerBI/MetadataTools.cs
@@ -26,9 +26,9 @@ namespace TestWpfPowerBI.PowerBI
         {
             return Client.Groups.GetGroups().Value;
         }
-        public IList<Dataset> GetDatasets(Group group)
+        public IList<Dataset> GetDatasets(Guid groupId)
         {
-            return Client.Datasets.GetDatasetsInGroup(group.Id).Value;
+            return Client.Datasets.GetDatasetsInGroup(groupId).Value;
         }
         public IList<Dataset> GetDatasets()
         {
@@ -37,30 +37,27 @@ namespace TestWpfPowerBI.PowerBI
 
         internal class DynamicDatasets
         {
-            public DynamicDatasets( Group group )
+            private MetadataTools _parent;
+            public DynamicDatasets(MetadataTools parent)
             {
-                this.Group = group;
+                _parent = parent;
             }
 
-            public Group Group { get; }
-
-            public IEnumerable<TreeViewPbiItem> GetChildren(IEventAggregator eventAggregator)
+            public IEnumerable<TreeViewPbiItem> GetChildren(TreeViewPbiItem item, IEventAggregator eventAggregator)
             {
-                var datasets = Group?.Datasets;
+                
 
-                if (datasets != null)
-                {
-                    var pbiDatasets = 
-                        from d in datasets 
-                        select new TreeViewPbiDataset(d, null, eventAggregator);
-                    return pbiDatasets;
-                }
-                else
-                {
-                    var pbiDummyDatasets = new List<TreeViewPbiItem>();
-                    pbiDummyDatasets.Add(new TreeViewPbiDummy("Loading...", null, null));
-                    return pbiDummyDatasets;
-                }
+                //if (item.Children != null)
+                //{
+                    return from d in _parent.GetDatasets(item.Id) select new TreeViewPbiDataset(d,null,null)
+                           ;
+                //}
+                //else
+                //{
+                //    var pbiDummyDatasets = new List<TreeViewPbiItem>();
+                //    pbiDummyDatasets.Add(new TreeViewPbiDummy("Loading...", null, null));
+                //    return pbiDummyDatasets;
+                //}
             }
         }
         
@@ -69,7 +66,7 @@ namespace TestWpfPowerBI.PowerBI
         {
             var pbiGroups =
                 from g in Client.Groups.GetGroups().Value
-                select new TreeViewPbiGroup(g, (new DynamicDatasets(g)).GetChildren, eventAggregator);
+                select new TreeViewPbiGroup(g, (new DynamicDatasets(this)).GetChildren, eventAggregator);
             return pbiGroups.ToList();
         }
 

--- a/utils/TestWpfPowerBI/TestWpfPowerBI.csproj
+++ b/utils/TestWpfPowerBI/TestWpfPowerBI.csproj
@@ -157,10 +157,10 @@
       <Version>3.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64">
-      <Version>19.69.2.2</Version>
+      <Version>19.77.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AnalysisServices.retail.amd64">
-      <Version>19.69.2.2</Version>
+      <Version>19.77.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Expression.Drawing">
       <Version>3.0.0</Version>
@@ -169,7 +169,7 @@
       <Version>4.43.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.PowerBI.Api">
-      <Version>3.26.0</Version>
+      <Version>4.18.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>

--- a/utils/TestWpfPowerBI/Views/PbiMetadataTreeView.xaml.cs
+++ b/utils/TestWpfPowerBI/Views/PbiMetadataTreeView.xaml.cs
@@ -31,7 +31,7 @@ namespace TestWpfPowerBI.Views
         {
             if (e.NewValue is TreeViewPbiGroup newTreeViewPbiGroup)
             {
-                SelectedGroup = newTreeViewPbiGroup.Group as Group;
+                SelectedGroup = newTreeViewPbiGroup;
                 SelectedDataset = null;
                 GroupChanged?.Invoke(this, EventArgs.Empty);
             }
@@ -47,7 +47,7 @@ namespace TestWpfPowerBI.Views
         public event EventHandler DatasetChanged;
         public event EventHandler GroupExpanded;
 
-        public Group SelectedGroup { get; private set; }
+        public TreeViewPbiGroup SelectedGroup { get; private set; }
 
         public Dataset SelectedDataset { get; private set; }
 
@@ -68,7 +68,7 @@ namespace TestWpfPowerBI.Views
                 Log.Information("Unknown expanded event");
                 return;
             }
-            if (group?.Group.Datasets == null)
+            if (group?.Datasets == null)
             {
                 Log.Information($"Loading {group.Name} group");
                 GroupExpanded?.Invoke(this, new GroupExpandedEventArgs(group));


### PR DESCRIPTION
Added 3 different modes for direct lake models so that we do not always force all columns to be transcoded into memory.

* **ResidentOnly** - only run the distinctcount queries on columns that are current resident in memory
* **Referenced** - run distinctcount queries on columns that are referenced by measures or relationships. This should provide the minimum information required for performance analysis of measures and for tools like DAX Optimizer.
* **Full** - run distinctcount queries on all columns

I've added this option since the default behaviour at the moment is the same as **Full** and this can be detrimental to large models. It can take longer than necessary and potentially may still not produce the desired result since as we cycle through all the columns it could force some of the earlier columns to be paged out of memory.

I've set **ResidentOnly** as the default as it's the cheapest/fastest option.

Note that if an option other than **ResidentOnly** is chosen I am re-running the DMV collection after the stats collection has been run since the memory usage is usually changed as a result of running the distinctcount queries.

I did consider whether to add the selected Direct Lake analysis mode as a property to the vpax file, but I decided against his for the time being since it can be implied by checking the IsResident property on a column.
