### PR TITLE
Minor fixes for DirectLake metric collection

### DIFF
--- a/src/Dax.Model.Extractor/StatExtractor.cs
+++ b/src/Dax.Model.Extractor/StatExtractor.cs
@@ -106,12 +106,8 @@ USERELATIONSHIP( {EscapeColumnName(rel.FromColumn)}, {EscapeColumnName(rel.ToCol
             {
                 var loopInvalidRelationships = relationshipList.Where(r => r.InvalidRows > 0).ToList().SplitList(10);
                 #region Details
-                foreach (var relationshipSetComplete in loopInvalidRelationships)
+                foreach (var relationshipSet in loopInvalidRelationships)
                 {
-                    var relationshipSet =
-                        relationshipSetComplete
-                        .Where(rel => analyzeDirectQuery || ((!rel.FromColumn.Table.HasDirectQueryPartitions) && (!rel.ToColumn.Table.HasDirectQueryPartitions)))
-                        .ToList();
                     // Skip EVALUATE if no valid relationships are found
                     if (!relationshipSet.Any()) continue;
 

--- a/src/Dax.Model.Extractor/TomExtractor.cs
+++ b/src/Dax.Model.Extractor/TomExtractor.cs
@@ -296,8 +296,13 @@ namespace Dax.Metadata.Extractor
                 Dax.Metadata.Extractor.DmvExtractor.PopulateFromDmv(daxModel, connection, serverName, databaseName, applicationName, applicationVersion);
 
                 // Populate statistics by querying the data model
-                if (readStatisticsFromData) {
+                if (readStatisticsFromData)
+                {
                     Dax.Metadata.Extractor.StatExtractor.UpdateStatisticsModel(daxModel, connection, sampleRows, analyzeDirectQuery, analyzeDirectLake);
+
+                    // if we have forced all columns into memory then re-run the DMVs to update the data with the new values after everything has been transcoded.
+                    if (analyzeDirectLake > DirectLakeExtractionMode.ResidentOnly)
+                        Dax.Metadata.Extractor.DmvExtractor.PopulateFromDmv(daxModel, connection, serverName, databaseName, applicationName, applicationVersion);
                 }
             }
             return daxModel;
@@ -353,9 +358,9 @@ namespace Dax.Metadata.Extractor
                 {
                     Dax.Metadata.Extractor.StatExtractor.UpdateStatisticsModel(daxModel, connection, sampleRows, analyzeDirectQuery, analyzeDirectLake);
 
-                // if we have forced all columns into memory then re-run the DMVs to update the data with the new values after everything has been transcoded.
+                    // if we have forced all columns into memory then re-run the DMVs to update the data with the new values after everything has been transcoded.
                     if (analyzeDirectLake > DirectLakeExtractionMode.ResidentOnly)
-                    Dax.Metadata.Extractor.DmvExtractor.PopulateFromDmv(daxModel, connection, serverName, databaseName, applicationName, applicationVersion);
+                        Dax.Metadata.Extractor.DmvExtractor.PopulateFromDmv(daxModel, connection, serverName, databaseName, applicationName, applicationVersion);
                 }
             }
             return daxModel;

--- a/src/Dax.Model.Extractor/TomExtractor.cs
+++ b/src/Dax.Model.Extractor/TomExtractor.cs
@@ -351,11 +351,10 @@ namespace Dax.Metadata.Extractor
                 // Populate statistics by querying the data model
                 if (readStatisticsFromData)
                 {
-                    Dax.Metadata.Extractor.StatExtractor.UpdateStatisticsModel(daxModel, connection, sampleRows, analyzeDirectQuery, analyzeDirectLake );
-                }
+                    Dax.Metadata.Extractor.StatExtractor.UpdateStatisticsModel(daxModel, connection, sampleRows, analyzeDirectQuery, analyzeDirectLake);
 
                 // if we have forced all columns into memory then re-run the DMVs to update the data with the new values after everything has been transcoded.
-                if (analyzeDirectLake > DirectLakeExtractionMode.ResidentOnly) {
+                    if (analyzeDirectLake > DirectLakeExtractionMode.ResidentOnly)
                     Dax.Metadata.Extractor.DmvExtractor.PopulateFromDmv(daxModel, connection, serverName, databaseName, applicationName, applicationVersion);
                 }
             }


### PR DESCRIPTION
- Re-run `DmvExtractor` only if `readStatisticsFromData` is enabled
- Add `DmvExtractor` re-run to `GetDaxModel` overload
- Remove `analyzeDirectQuery` filter when retrieving referential integrity violations