### PR TITLE
Fix for TomConnection NotImplementedException

### DIFF
--- a/src/Dax.Model.Extractor/Data/IDbConnectionExtensions.cs
+++ b/src/Dax.Model.Extractor/Data/IDbConnectionExtensions.cs
@@ -13,7 +13,7 @@ namespace Dax.Model.Extractor.Data
                 AdomdConnection adomdConnection => new AdomdCommand(commandText, adomdConnection),
                 OleDbConnection oledbConnection => new OleDbCommand(commandText, oledbConnection),
                 TomConnection tomConnection => new TomCommand(commandText, tomConnection),
-                _ => throw new ExtractorException(connection),
+                _ => connection.CreateCommand(commandText)
             };
         }
     }

--- a/src/Dax.Model.Extractor/Data/TomConnection.cs
+++ b/src/Dax.Model.Extractor/Data/TomConnection.cs
@@ -33,34 +33,29 @@ namespace Dax.Model.Extractor.Data
         {
         }
 
-        #region Methods and properties that throw a NotImplementedException
+        public ConnectionState State => Server.GetConnectionState(false);
 
         public string ConnectionString {
-            get { throw new NotImplementedException(); }
-            set { throw new NotImplementedException(); }
+            get { return Server.ConnectionString; }
+            set { throw new InvalidOperationException(); }
         }
+        public int ConnectionTimeout => Server.ConnectionInfo.Timeout;
 
-        public int ConnectionTimeout {
-            get { throw new NotImplementedException(); }
-        }
-
-        public ConnectionState State {
-            get { throw new NotImplementedException(); }
-        }
+        #region Methods and properties that throw a NotSupportedException
 
         public IDbTransaction BeginTransaction()
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public IDbTransaction BeginTransaction(IsolationLevel il)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public void ChangeDatabase(string databaseName)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         #endregion


### PR DESCRIPTION
After upgrading to 1.5.0, Tabular Editor 3 is not able to collect VertiPaq Analyzer stats, because we use the TomConnection wrapper for an existing connection created using AMO/TOM.

In 1.5.0, the connection's State property is read inside the DmvExtractor. However, the State property was not mplemented for the TomConnection wrapper. This PR fixes that.