### PR TITLE
[cli] Bump VPAX 1.7.0, add advanced export options

### DIFF
--- a/src/Dax.Vpax.CLI/Commands/ExportCommand.cs
+++ b/src/Dax.Vpax.CLI/Commands/ExportCommand.cs
@@ -14,8 +14,12 @@ internal static class ExportCommand
             PathArgument,
             ConnectionStringArgument,
             OverwriteOption,
+            // advanced options
             ExcludeTomOption,
-            ExcludeVpaOption
+            ExcludeVpaOption,
+            DirectQueryModeOption,
+            DirectLakeModeOption,
+            ColumnBatchSizeOption,
         };
         command.Handler = s_handler;
         return command;

--- a/src/Dax.Vpax.CLI/Commands/ExportCommandHandler.cs
+++ b/src/Dax.Vpax.CLI/Commands/ExportCommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.CommandLine.Invocation;
+﻿using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using Dax.Metadata;
 using Dax.Model.Extractor;
@@ -23,6 +24,9 @@ internal sealed class ExportCommandHandler : ICommandHandler
         var overwrite = context.ParseResult.GetValueForOption(OverwriteOption);
         var excludeTom = context.ParseResult.GetValueForOption(ExcludeTomOption);
         var excludeVpa = context.ParseResult.GetValueForOption(ExcludeVpaOption);
+        var directQueryMode = context.ParseResult.GetValueForOption(DirectQueryModeOption);
+        var directLakeMode = context.ParseResult.GetValueForOption(DirectLakeModeOption);
+        var columnBatchSize = context.ParseResult.GetValueForOption(ColumnBatchSizeOption);
 
         using var vpaxStream = new MemoryStream();
 
@@ -34,9 +38,10 @@ internal sealed class ExportCommandHandler : ICommandHandler
                 applicationName: extractorAppName,
                 applicationVersion: extractorAppVersion,
                 readStatisticsFromData: true,
-                sampleRows: 0, // RI violation sampling is not applicable to VPAX files
-                analyzeDirectQuery: true,
-                analyzeDirectLake: DirectLakeExtractionMode.Full
+                sampleRows: 0, // not applicable for VPAX export
+                analyzeDirectQuery: directQueryMode != DirectQueryExtractionMode.None,
+                analyzeDirectLake: directLakeMode,
+                statsColumnBatchSize: columnBatchSize
                 );
 
             var vpaModel = excludeVpa ? null : new ViewVpaExport.Model(daxModel);

--- a/src/Dax.Vpax.CLI/Commands/ExportCommandOptions.cs
+++ b/src/Dax.Vpax.CLI/Commands/ExportCommandOptions.cs
@@ -1,4 +1,6 @@
-﻿using System.CommandLine;
+﻿using Dax.Metadata;
+using Dax.Model.Extractor;
+using System.CommandLine;
 using System.Data.Common;
 
 namespace Dax.Vpax.CLI.Commands;
@@ -43,4 +45,27 @@ internal static class ExportCommandOptions
         getDefaultValue: () => false,
         description: "Exclude the VPA model (DaxVpaView.json) from the export"
         );
+
+    public static readonly Option<DirectQueryExtractionMode> DirectQueryModeOption = new(
+        name: "--direct-query-mode",
+        getDefaultValue: () => DirectQueryExtractionMode.Full,
+        description: "Direct Query extraction mode"
+        );
+
+    public static readonly Option<DirectLakeExtractionMode> DirectLakeModeOption = new(
+        name: "--direct-lake-mode",
+        getDefaultValue: () => DirectLakeExtractionMode.Full,
+        description: "Direct Lake extraction mode"
+        );
+
+    public static readonly Option<int> ColumnBatchSizeOption = new(
+        name: "--column-batch-size",
+        getDefaultValue: () => StatExtractor.DefaultColumnBatchSize,
+        description: "Number of rows processed at a time during column statistics analysis"
+        );
+
+    //static ExportCommandOptions()
+    //{
+    //    //ExtractorDirectLakeMode.FromAmong();
+    //}
 }

--- a/src/Dax.Vpax.CLI/Dax.Vpax.CLI.csproj
+++ b/src/Dax.Vpax.CLI/Dax.Vpax.CLI.csproj
@@ -27,8 +27,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dax.Model.Extractor" Version="1.6.0" />
-    <PackageReference Include="Dax.Vpax" Version="1.6.0" />
+    <PackageReference Include="Dax.Model.Extractor" Version="1.7.0" />
+    <PackageReference Include="Dax.Vpax" Version="1.7.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Dax.Vpax.CLI/version.json
+++ b/src/Dax.Vpax.CLI/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1",
+  "version": "1.2",
   "nugetPackageVersion": {
     "semVer": 2
   },


### PR DESCRIPTION
Adds advanced extract option:

`--direct-query-mode` : [Direct Query extraction mode](https://github.com/sql-bi/VertiPaq-Analyzer/blob/8bd92126b3bbddfc1ec6c82c51d2d00c12ee2d3f/src/Dax.Metadata/ExtractorProperties.cs#L51-L62)
`--direct-lake-mode` : [Direct Lake extraction mode](https://github.com/sql-bi/VertiPaq-Analyzer/blob/8bd92126b3bbddfc1ec6c82c51d2d00c12ee2d3f/src/Dax.Metadata/ExtractorProperties.cs#L30C1-L49C2).
`--column-batch-size`: Number of rows processed at a time during column statistics analysis