### PR TITLE
Extend column statistics analysis to include columns with GroupByColumns

### DIFF
--- a/src/Dax.Model.Extractor/StatExtractor.cs
+++ b/src/Dax.Model.Extractor/StatExtractor.cs
@@ -257,7 +257,7 @@ USERELATIONSHIP( {EscapeColumnName(rel.FromColumn)}, {EscapeColumnName(rel.ToCol
                  // skip direct query tables if the analyzeDirectQuery is false
                  where t.Columns.Count > 1 && (analyzeDirectQuery || !t.HasDirectQueryPartitions)   
                      from c in t.Columns
-                     where c.State == "Ready" && !c.IsRowNumber && c.GroupByColumns.Count == 0
+                     where c.State == "Ready" && !c.IsRowNumber
                         // only include the column if the table does not have Direct Lake partitions or if they are resident or if analyzeDirectLake is true
                         && (!t.HasDirectLakePartitions 
                             || (analyzeDirectLake >= DirectLakeExtractionMode.ResidentOnly && c.IsResident) 

--- a/src/Dax.Model.Extractor/StatExtractor.cs
+++ b/src/Dax.Model.Extractor/StatExtractor.cs
@@ -237,9 +237,10 @@ USERELATIONSHIP( {EscapeColumnName(rel.FromColumn)}, {EscapeColumnName(rel.ToCol
 
         private static string DistinctCountExpression(Column column)
         {
-            return column.GroupByColumns.Count == 0 
-                ? $"DISTINCTCOUNT({EscapeColumnName(column)})"
-                : $"COUNTROWS(ALLNOBLANKROW({EscapeColumnName(column)}))";
+            // We always use COUNTROWS(ALLNOBLANKROW(t[c])) instead of DISTINCTCOUNT(t[c]) because it is compatible with GroupByColumns settings, such as Fields Parameters. 
+            // COUNTROWS(ALLNOBLANKROW()) always reads the list of values from the attribute hierarchy (when AvailableInMDX=true) or queries the table if the hierarchy is not available (when AvailableInMDX=false)
+
+            return $"COUNTROWS(ALLNOBLANKROW({EscapeColumnName(column)}))";
         }
 
         private static string EscapeColumnName(Column column)


### PR DESCRIPTION
This commit fixes an issue where the cardinality of a column would result in zero if the column had `GroupByColumns` specified and `IsAvailableInMDX=false`. This occurred because statistics for these columns are not available in the DMV `$SYSTEM.DISCOVER_STORAGE_TABLES` (see `WHERE LEFT(TABLE_ID, 2) = 'H$'` in PopulateColumnsCardinality).