### PR TITLE
Pin System.IO.Packaging to version range [6.0.0, 7.0.0)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
     <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="$(MicrosoftAnalysisServicesVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="System.IO.Packaging" Version="6.0.0" />
+    <PackageVersion Include="System.IO.Packaging" Version="[6.0.0, 7.0.0)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated the System.IO.Packaging version from fixed 6.0.0 to a range [6.0.0, 7.0.0) preventing major version upgrades