### PR TITLE
Add Table.DefaultDetailRowsExpression property, bump model version 1.6.0

### DIFF
--- a/src/Dax.Metadata/Table.cs
+++ b/src/Dax.Metadata/Table.cs
@@ -36,6 +36,7 @@ namespace Dax.Metadata
         public bool IsLocalDateTable { get; set; }
         public bool IsTemplateDateTable { get; set; }
         public DaxExpression TableExpression { get; set; }
+        public DaxExpression DefaultDetailRowsExpression { get; set; }
         public long RowsCount { get; set; }
         public long ReferentialIntegrityViolationCount { get; set; }
         public CalculationGroup CalculationGroup { get; set; }

--- a/src/Dax.Model.Extractor/TomExtractor.cs
+++ b/src/Dax.Model.Extractor/TomExtractor.cs
@@ -123,7 +123,8 @@ namespace Dax.Model.Extractor
                 TableType = isCalculatedTable ? Table.TableSourceType.CalculatedTable.ToString() :
                        (isCalculationGroup ? Table.TableSourceType.CalculationGroup.ToString() : null),
                 Description = new  DaxNote(table.Description),
-                IsDateTable = (table.DataCategory == Microsoft.AnalysisServices.DimensionType.Time.ToString())
+                IsDateTable = (table.DataCategory == Microsoft.AnalysisServices.DimensionType.Time.ToString()),
+                DefaultDetailRowsExpression = DaxExpression.GetExpression(table.DefaultDetailRowsDefinition?.Expression),
             };
             if (daxTable.IsDateTable == false)
             {

--- a/src/Dax.ViewVpaExport/Table.cs
+++ b/src/Dax.ViewVpaExport/Table.cs
@@ -31,5 +31,6 @@ namespace Dax.ViewVpaExport
         public long RelationshipsSize { get { return this._Table.RelationshipsSize; } }
         public long UserHierarchiesSize { get { return this._Table.UserHierarchiesSize; } }
         public bool IsReferenced { get { return this._Table.IsReferenced; } }
+        public string DefaultDetailRowsExpression { get { return this._Table.DefaultDetailRowsExpression?.Expression; } }
     }
 }


### PR DESCRIPTION
Add `Table.DefaultDetailRowsExpression` property to support extraction for table detail rows expression.
The property has been added to both `Dax.Model.Table` and `Dax.ViewVpaExport.Table`.
Bumped `Dax.Model.Version` to 1.6.0
