### PR TITLE
Bump Microsoft.AnalysisServices deps from 19.86.6 to 19.90.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AnalysisServices" Version="19.86.6" />
-    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient" Version="19.86.6" />
+    <PackageVersion Include="Microsoft.AnalysisServices" Version="19.90.0" />
+    <PackageVersion Include="Microsoft.AnalysisServices.AdomdClient" Version="19.90.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.IO.Packaging" Version="8.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Updated the `Microsoft.AnalysisServices` and `Microsoft.AnalysisServices.AdomdClient` package versions from `19.86.6` to `19.90.0`