### PR TITLE
Exclude parent entity $ref from JSON serialization, fix null CalculationGroup.Table after deserialization

### DIFF
--- a/src/Dax.Metadata/CalculationGroup.cs
+++ b/src/Dax.Metadata/CalculationGroup.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
 
@@ -15,10 +16,18 @@ namespace Dax.Metadata
             this.CalculationItems = new List<CalculationItem>();
         }
 
+        [JsonIgnore]
         public Table Table { get; set; }
 
         public int Precedence { get; set; }
 
         public List<CalculationItem> CalculationItems { get; }
+
+        [OnDeserialized]
+        internal void OnDeserializedMethod(StreamingContext context)
+        {
+            foreach (var i in CalculationItems)
+                i.CalculationGroup = this;            
+        }
     }
 }

--- a/src/Dax.Metadata/CalculationItem.cs
+++ b/src/Dax.Metadata/CalculationItem.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using Newtonsoft.Json;
+using System.Diagnostics;
 
 namespace Dax.Metadata
 {
@@ -11,6 +12,7 @@ namespace Dax.Metadata
         }
         private CalculationItem() { }
 
+        [JsonIgnore]
         public CalculationGroup CalculationGroup { get; set; }
 
         public DaxName ItemName { get; set; }

--- a/src/Dax.Metadata/Column.cs
+++ b/src/Dax.Metadata/Column.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using System.Runtime.Serialization;
@@ -20,6 +21,7 @@ namespace Dax.Metadata
             GroupByColumns = new List<DaxName>();
         }
 
+        [JsonIgnore]
         public Table Table { get; set; }
         public DaxName ColumnName { get; set; }
         public long ColumnCardinality { get; set; }

--- a/src/Dax.Metadata/ColumnHierarchy.cs
+++ b/src/Dax.Metadata/ColumnHierarchy.cs
@@ -29,6 +29,7 @@ WHERE LEFT ( TABLE_ID, 2 ) = 'H$'
         }
         private ColumnHierarchy() { }
 
+        [JsonIgnore]
         public Column Column { get; set; }
 
         public DaxName StructureName { get; set; }

--- a/src/Dax.Metadata/ColumnSegment.cs
+++ b/src/Dax.Metadata/ColumnSegment.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,6 +17,7 @@ namespace Dax.Metadata
 
         private ColumnSegment() { }
 
+        [JsonIgnore]
         public Column Column { get; set; }
         public Partition Partition { get; set; }
         public long SegmentNumber { get; set; }

--- a/src/Dax.Metadata/Measure.cs
+++ b/src/Dax.Metadata/Measure.cs
@@ -1,10 +1,12 @@
-﻿using System.Diagnostics;
+﻿using Newtonsoft.Json;
+using System.Diagnostics;
 
 namespace Dax.Metadata
 {
     [DebuggerDisplay("{MeasureName.Name,nq}")]
     public class Measure
     {
+        [JsonIgnore]
         public Table Table { get; set; }
         public DaxName MeasureName { get; set; }
         public DaxExpression MeasureExpression { get; set; }

--- a/src/Dax.Metadata/Model.cs
+++ b/src/Dax.Metadata/Model.cs
@@ -132,6 +132,16 @@ namespace Dax.Metadata
         [OnDeserialized]
         internal void OnDeserializedMethod(StreamingContext context)
         {
+            foreach (var t in Tables)
+                t.Model = this;
+
+            // TODO: Add the Model property to Relationship, as done for other top-level entities
+            //foreach (var r in Relationships)
+            //    r.Model = this;
+
+            foreach (var r in Roles)
+                r.Model = this;
+
             foreach (var f in Functions)
                 f.Model = this;
         }

--- a/src/Dax.Metadata/Partition.cs
+++ b/src/Dax.Metadata/Partition.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Diagnostics;
 
 namespace Dax.Metadata
@@ -47,6 +48,7 @@ namespace Dax.Metadata
         }
         private Partition() { }
 
+        [JsonIgnore]
         public Table Table { get; set; }
         public DaxName PartitionName { get; set; }
         public long PartitionNumber { get; set; }

--- a/src/Dax.Metadata/Role.cs
+++ b/src/Dax.Metadata/Role.cs
@@ -9,7 +9,7 @@ namespace Dax.Metadata
     public class Role
     {
         [JsonIgnore]
-        public Model Model;
+        public Model Model { get; set; }
 
         public DaxName RoleName { get; set; }
         public List<TablePermission> TablePermissions { get; }

--- a/src/Dax.Metadata/Table.cs
+++ b/src/Dax.Metadata/Table.cs
@@ -27,7 +27,8 @@ namespace Dax.Metadata
             Partitions = new List<Partition>();
         }
 
-        public Model Model;
+        [JsonIgnore]
+        public Model Model { get; set; }
 
         public DaxName TableName { get; set; }
         public string TableType { get; set; }
@@ -204,7 +205,7 @@ namespace Dax.Metadata
         [OnDeserialized]
         internal void OnDeserializedMethod(StreamingContext context)
         {
-            foreach ( var c in Columns ) {
+            foreach (var c in Columns) {
                 c.Table = this;
             }
             foreach (var m in Measures) {
@@ -216,6 +217,9 @@ namespace Dax.Metadata
             foreach (var p in Partitions) {
                 p.Table = this;
             }
+
+            if (CalculationGroup != null)
+                CalculationGroup.Table = this;
         }
     }
 }

--- a/src/Dax.Metadata/TablePermission.cs
+++ b/src/Dax.Metadata/TablePermission.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +9,7 @@ namespace Dax.Metadata
 {
     public class TablePermission
     {
+        [JsonIgnore]
         public Role Role { get; set; }
         public Table Table { get; set; }
         public DaxExpression FilterExpression { get; set; }

--- a/src/Dax.Metadata/UserHierarchy.cs
+++ b/src/Dax.Metadata/UserHierarchy.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Dax.Metadata
@@ -6,6 +7,7 @@ namespace Dax.Metadata
     [DebuggerDisplay("{HierarchyName.Name,nq}")]
     public class UserHierarchy
     {
+        [JsonIgnore]
         public Table Table { get; set; }
         public DaxName HierarchyName { get; set; }
         public bool IsHidden { get; set; }


### PR DESCRIPTION
Parent navigation properties (e.g., `column.Table`) are now excluded from JSON serialization. These properties are used by child entities to access their parent objects, but they are automatically reassigned during deserialization via the `OnDeserialized` attribute/ method. Therefore, including them in the JSON is redundant. By excluding these references, we also reduce the overall JSON size and avoid generating unnecessary object $ref entries.