### PR TITLE
Support `CalculationGroup.MultipleOrEmpty` and `NoSelection` expressions. Bump model version to 1.8.0

### DIFF
--- a/src/Dax.Metadata/CalculationGroup.cs
+++ b/src/Dax.Metadata/CalculationGroup.cs
@@ -23,6 +23,14 @@ namespace Dax.Metadata
 
         public List<CalculationItem> CalculationItems { get; }
 
+        public DaxExpression MultipleOrEmptySelectionExpression { get; set; }
+
+        public DaxExpression MultipleOrEmptySelectionFormatStringExpression { get; set; }
+
+        public DaxExpression NoSelectionExpression { get; set; }
+
+        public DaxExpression NoSelectionFormatStringExpression { get; set; }
+
         [OnDeserialized]
         internal void OnDeserializedMethod(StreamingContext context)
         {

--- a/src/Dax.Metadata/Model.cs
+++ b/src/Dax.Metadata/Model.cs
@@ -111,7 +111,7 @@ namespace Dax.Metadata
 
         // Manually update the version each time the DaxModel is modified - use https://semver.org/ specification
         [JsonIgnore]
-        public static readonly string CurrentDaxModelVersion = new Version(1, 7, 0).ToString(3);
+        public static readonly string CurrentDaxModelVersion = new Version(1, 8, 0).ToString(3);
 
         public Model(string extractorLib, string extractorLibVersion, string extractorApp = null, string extractorAppVersion = null) : this()
         {

--- a/src/Dax.Model.Extractor/TomExtractor.cs
+++ b/src/Dax.Model.Extractor/TomExtractor.cs
@@ -181,7 +181,11 @@ namespace Dax.Model.Extractor
             if (table.CalculationGroup != null) {
                 CalculationGroup calcGroup = new(daxTable)
                 {
-                    Precedence = table.CalculationGroup.Precedence
+                    Precedence = table.CalculationGroup.Precedence,
+                    MultipleOrEmptySelectionExpression = DaxExpression.GetExpression(table.CalculationGroup.MultipleOrEmptySelectionExpression?.Expression),
+                    MultipleOrEmptySelectionFormatStringExpression = DaxExpression.GetExpression(table.CalculationGroup.MultipleOrEmptySelectionExpression?.FormatStringDefinition?.Expression),
+                    NoSelectionExpression = DaxExpression.GetExpression(table.CalculationGroup.NoSelectionExpression?.Expression),
+                    NoSelectionFormatStringExpression = DaxExpression.GetExpression(table.CalculationGroup.NoSelectionExpression?.FormatStringDefinition?.Expression),
                 };
                 foreach (Tom.CalculationItem calcItem in table.CalculationGroup.CalculationItems) {
                     AddCalculationItem(calcGroup, calcItem);

--- a/src/Dax.ViewVpaExport/CalculationGroup.cs
+++ b/src/Dax.ViewVpaExport/CalculationGroup.cs
@@ -1,0 +1,19 @@
+﻿namespace Dax.ViewVpaExport
+{
+    public class CalculationGroup
+    {
+        private readonly Dax.Metadata.CalculationGroup _calculationGroup;
+
+        internal CalculationGroup(Dax.Metadata.CalculationGroup calculationGroup)
+        {
+            _calculationGroup = calculationGroup;
+        }
+
+        public string MultipleOrEmptySelectionExpression => _calculationGroup.MultipleOrEmptySelectionExpression?.Expression;
+        public string MultipleOrEmptySelectionFormatStringExpression => _calculationGroup.MultipleOrEmptySelectionFormatStringExpression?.Expression;
+        public string NoSelectionExpression => _calculationGroup.NoSelectionExpression?.Expression;
+        public string NoSelectionFormatStringExpression => _calculationGroup.NoSelectionFormatStringExpression?.Expression;
+        public int Precedence => _calculationGroup.Precedence;
+        public string TableName => _calculationGroup.Table.TableName.Name;
+    }
+}

--- a/src/Dax.ViewVpaExport/Model.cs
+++ b/src/Dax.ViewVpaExport/Model.cs
@@ -74,6 +74,15 @@ namespace Dax.ViewVpaExport
             }
         }
 
+        public IEnumerable<CalculationGroup> CalculationGroups {
+            get {
+                return
+                    from t in this._Model.Tables
+                    where t.CalculationGroup != null
+                    select new CalculationGroup(t.CalculationGroup);
+            }
+        }
+
         public IEnumerable<CalculationItem> CalculationItems {
             get {
                 return


### PR DESCRIPTION
This pull request introduces support for additional expression types within calculation groups and updates the DAX model version. The key changes include the addition of new properties for handling selection expressions in calculation groups, updates to the model extractor to populate these properties, and the introduction of a new `CalculationGroup` class in the `Dax.ViewVpaExport` namespace to expose these properties.

### Enhancements to Calculation Groups:

* [`src/Dax.Metadata/CalculationGroup.cs`](diffhunk://#diff-0046c13686610ccc5dd3cb6b40c1a9b0e68363550a55b9a82632c6fa63e728c1R26-R33): Added new properties to `CalculationGroup` for `MultipleOrEmptySelectionExpression`, `MultipleOrEmptySelectionFormatStringExpression`, `NoSelectionExpression`, and `NoSelectionFormatStringExpression`. These properties will store the respective DAX expressions.

* [`src/Dax.Model.Extractor/TomExtractor.cs`](diffhunk://#diff-d56b1e47e7b80000e9032f424d11e18448b2118ddee94a3150e3c1f790905decL184-R188): Updated the `AddTable` method to populate the new properties in `CalculationGroup` by extracting the corresponding expressions from the TOM (Tabular Object Model).

* [`src/Dax.ViewVpaExport/CalculationGroup.cs`](diffhunk://#diff-4fd6d53fdfa789cb68c858916d750b2a9a462b19a17e9a01166b652db993d699R1-R19): Introduced a new `CalculationGroup` class to expose the new properties (`MultipleOrEmptySelectionExpression`, `MultipleOrEmptySelectionFormatStringExpression`, `NoSelectionExpression`, `NoSelectionFormatStringExpression`) along with existing ones like `Precedence` and `TableName`.

* [`src/Dax.ViewVpaExport/Model.cs`](diffhunk://#diff-1ca984ef6efbc02831c74160fb4169dcc293dd0a1667517f9150c51dc417b2cdR77-R85): Added a `CalculationGroups` property to the `Model` class to provide access to the new `CalculationGroup` instances.

### DAX Model Version Update:

* [`src/Dax.Metadata/Model.cs`](diffhunk://#diff-1cb47bd2f1be9339500f677776ee75d8273670931d48f5c2f076ad3a6c624fe4L114-R114): Updated the `CurrentDaxModelVersion` to `1.8.0` to reflect the addition of new features.