### PR TITLE
Fixup - remove JsonIgnore from Metadata.Table.Model property

### DIFF
--- a/src/Dax.Metadata/Table.cs
+++ b/src/Dax.Metadata/Table.cs
@@ -27,7 +27,12 @@ namespace Dax.Metadata
             Partitions = new List<Partition>();
         }
 
-        [JsonIgnore]
+        // JsonIgnore for Model property was introduced in VAPX 1.11-preview2 but later commented out 
+        // to avoid breaking changes when the model was extracted using an earlier version of the library.
+        // This is due to the Model property not being set after deserialization. 
+        // See Metadata.Model.OnDeserializedMethod in https://github.com/sql-bi/VertiPaq-Analyzer/pull/200.
+        // Consider uncommenting in a future version.
+        //[JsonIgnore]
         public Model Model { get; set; }
 
         public DaxName TableName { get; set; }


### PR DESCRIPTION
The `[JsonIgnore]` attribute was removed from the `Model` property in the `Dax.Metadata` namespace. Comments were added to explain the history of this change, noting that the attribute was initially introduced in VAPX 1.11-preview2 but was commented out to avoid breaking changes during deserialization with earlier library versions. The comments also reference a related pull request and suggest the possibility of uncommenting the attribute in future versions.