### PR TITLE
Add Description property for CalculationGroup and Selection expressions

### DIFF
--- a/src/Dax.Metadata/CalculationGroup.cs
+++ b/src/Dax.Metadata/CalculationGroup.cs
@@ -23,11 +23,17 @@ namespace Dax.Metadata
 
         public List<CalculationItem> CalculationItems { get; }
 
+        public DaxNote Description { get; set; }
+
         public DaxExpression MultipleOrEmptySelectionExpression { get; set; }
+
+        public DaxNote MultipleOrEmptySelectionExpressionDescription { get; set; }
 
         public DaxExpression MultipleOrEmptySelectionFormatStringExpression { get; set; }
 
         public DaxExpression NoSelectionExpression { get; set; }
+
+        public DaxNote NoSelectionExpressionDescription { get; set; }
 
         public DaxExpression NoSelectionFormatStringExpression { get; set; }
 

--- a/src/Dax.Model.Extractor/TomExtractor.cs
+++ b/src/Dax.Model.Extractor/TomExtractor.cs
@@ -182,9 +182,12 @@ namespace Dax.Model.Extractor
                 CalculationGroup calcGroup = new(daxTable)
                 {
                     Precedence = table.CalculationGroup.Precedence,
+                    Description = new DaxNote(table.CalculationGroup.Description),
                     MultipleOrEmptySelectionExpression = DaxExpression.GetExpression(table.CalculationGroup.MultipleOrEmptySelectionExpression?.Expression),
+                    MultipleOrEmptySelectionExpressionDescription = new DaxNote(table.CalculationGroup.MultipleOrEmptySelectionExpression?.Description),
                     MultipleOrEmptySelectionFormatStringExpression = DaxExpression.GetExpression(table.CalculationGroup.MultipleOrEmptySelectionExpression?.FormatStringDefinition?.Expression),
                     NoSelectionExpression = DaxExpression.GetExpression(table.CalculationGroup.NoSelectionExpression?.Expression),
+                    NoSelectionExpressionDescription = new DaxNote(table.CalculationGroup.NoSelectionExpression?.Description),
                     NoSelectionFormatStringExpression = DaxExpression.GetExpression(table.CalculationGroup.NoSelectionExpression?.FormatStringDefinition?.Expression),
                 };
                 foreach (Tom.CalculationItem calcItem in table.CalculationGroup.CalculationItems) {

--- a/src/Dax.ViewVpaExport/CalculationGroup.cs
+++ b/src/Dax.ViewVpaExport/CalculationGroup.cs
@@ -9,9 +9,13 @@
             _calculationGroup = calculationGroup;
         }
 
+        public string Description => _calculationGroup.Description?.Note;
+        public bool IsHidden => _calculationGroup.Table.IsHidden;
         public string MultipleOrEmptySelectionExpression => _calculationGroup.MultipleOrEmptySelectionExpression?.Expression;
+        public string MultipleOrEmptySelectionExpressionDescription => _calculationGroup.MultipleOrEmptySelectionExpressionDescription?.Note;
         public string MultipleOrEmptySelectionFormatStringExpression => _calculationGroup.MultipleOrEmptySelectionFormatStringExpression?.Expression;
         public string NoSelectionExpression => _calculationGroup.NoSelectionExpression?.Expression;
+        public string NoSelectionExpressionDescription => _calculationGroup.NoSelectionExpressionDescription?.Note;
         public string NoSelectionFormatStringExpression => _calculationGroup.NoSelectionFormatStringExpression?.Expression;
         public int Precedence => _calculationGroup.Precedence;
         public string TableName => _calculationGroup.Table.TableName.Name;


### PR DESCRIPTION
This pull request introduces enhancements to the `CalculationGroup` class and related methods to support descriptions for `MultipleOrEmptySelectionExpression` and `NoSelectionExpression`DAX expressions. 

### `CalculationGroup` Metadata:

* [`src/Dax.Metadata/CalculationGroup.cs`](diffhunk://#diff-0046c13686610ccc5dd3cb6b40c1a9b0e68363550a55b9a82632c6fa63e728c1R26-R37): Added new properties to the `CalculationGroup` class to store descriptions for `MultipleOrEmptySelectionExpression`, `NoSelectionExpression`, and the overall `CalculationGroup`. 

* [`src/Dax.Model.Extractor/TomExtractor.cs`](diffhunk://#diff-d56b1e47e7b80000e9032f424d11e18448b2118ddee94a3150e3c1f790905decR185-R190): Updated the `AddTable` method to populate the new description properties (`Description`, `MultipleOrEmptySelectionExpressionDescription`, and `NoSelectionExpressionDescription`) when creating a `CalculationGroup` from a TOM table.

### `CalculationGroup` VpaView:

* [`src/Dax.ViewVpaExport/CalculationGroup.cs`](diffhunk://#diff-4fd6d53fdfa789cb68c858916d750b2a9a462b19a17e9a01166b652db993d699R12-R18): Added accessor properties to expose the new description fields (`Description`, `MultipleOrEmptySelectionExpressionDescription`, and `NoSelectionExpressionDescription`) as strings.