### PR TITLE
Add `Dax.Metadata.Calendar`, bump model version to 1.9.0

### DIFF
--- a/src/Dax.Metadata/Calendar.cs
+++ b/src/Dax.Metadata/Calendar.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace Dax.Metadata
+{
+    [DebuggerDisplay("{CalendarName.Name,nq}")]
+    public class Calendar
+    {
+        public List<CalendarColumnGroup> CalendarColumnGroups { get; set; } = [];
+
+        public DaxName CalendarName { get; set; }
+
+        public DaxNote Description { get; set; }
+
+        [JsonIgnore]
+        public Table Table { get; set; }
+
+        [OnDeserialized]
+        private void OnDeserializedMethod(StreamingContext context)
+        {
+            foreach (var ccg in CalendarColumnGroups)
+                ccg.Calendar = this;
+        }
+    }
+}

--- a/src/Dax.Metadata/CalendarColumnGroup.cs
+++ b/src/Dax.Metadata/CalendarColumnGroup.cs
@@ -1,0 +1,27 @@
+﻿using Dax.Metadata.JsonConverters;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Dax.Metadata
+{
+    [JsonConverter(typeof(CalendarColumnGroupCustomCreationConverter))]
+    public abstract class CalendarColumnGroup
+    {
+        [JsonIgnore]
+        public Calendar Calendar { get; set; }
+    }
+
+    public class TimeRelatedColumnGroup : CalendarColumnGroup
+    {
+        public List<Column> Columns { get; set; } = [];
+    }
+
+    public class TimeUnitColumnAssociation : CalendarColumnGroup
+    {
+        public List<Column> AssociatedColumns { get; set; } = [];
+
+        public Column PrimaryColumn { get; set; }
+
+        public TimeUnit TimeUnit { get; set; }
+    }
+}

--- a/src/Dax.Metadata/JsonConverters/CalendarColumnGroupCustomCreationConverter.cs
+++ b/src/Dax.Metadata/JsonConverters/CalendarColumnGroupCustomCreationConverter.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace Dax.Metadata.JsonConverters
+{   
+    /// <summary>
+    /// A custom creation converter for deserializing JSON into the appropriate concrete type of <see cref="CalendarColumnGroup"/>.
+    /// </summary>
+    /// <remarks>This converter determines the specific type of <see cref="CalendarColumnGroup"/> to
+    /// instantiate based on the presence of the <c>TimeUnit</c> property in the JSON data. If the <c>TimeUnit</c>
+    /// property is present, a <see cref="TimeUnitColumnAssociation"/> is created; otherwise, a <see
+    /// cref="TimeRelatedColumnGroup"/> is instantiated. <para> This implementation avoids using
+    /// <c>TypeNameHandling.All</c> due to security risks, as described in <see
+    /// href="https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2326"> CA2326: Do not
+    /// use TypeNameHandling.All</see>. Additionally, it avoids using <see cref="JsonConverter"/> directly to prevent
+    /// potential stack overflow issues caused by recursive calls, as noted in <see
+    /// href="https://github.com/JamesNK/Newtonsoft.Json/issues/719">GitHub issue #719</see>. </para></remarks>
+    public class CalendarColumnGroupCustomCreationConverter : CustomCreationConverter<CalendarColumnGroup>
+    {
+        private bool _isTimeUnitColumnAssociation; // Not thread-safe
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var jobject = JObject.Load(reader);
+
+            // Determine the concrete type based on the presence of the TimeUnit property used as discriminator
+            _isTimeUnitColumnAssociation = jobject.TryGetValue(nameof(TimeUnitColumnAssociation.TimeUnit), StringComparison.OrdinalIgnoreCase, out _);
+
+            return base.ReadJson(jobject.CreateReader(), objectType, existingValue, serializer);
+        }
+
+        public override CalendarColumnGroup Create(Type objectType)
+        {
+            if (_isTimeUnitColumnAssociation)
+                return new TimeUnitColumnAssociation();
+
+            return new TimeRelatedColumnGroup();
+        }        
+    }
+}

--- a/src/Dax.Metadata/Model.cs
+++ b/src/Dax.Metadata/Model.cs
@@ -111,7 +111,7 @@ namespace Dax.Metadata
 
         // Manually update the version each time the DaxModel is modified - use https://semver.org/ specification
         [JsonIgnore]
-        public static readonly string CurrentDaxModelVersion = new Version(1, 8, 0).ToString(3);
+        public static readonly string CurrentDaxModelVersion = new Version(1, 9, 0).ToString(3);
 
         public Model(string extractorLib, string extractorLibVersion, string extractorApp = null, string extractorAppVersion = null) : this()
         {

--- a/src/Dax.Metadata/Table.cs
+++ b/src/Dax.Metadata/Table.cs
@@ -25,6 +25,7 @@ namespace Dax.Metadata
             Measures = new List<Measure>();
             UserHierarchies = new List<UserHierarchy>();
             Partitions = new List<Partition>();
+            Calendars = new List<Calendar>();
         }
 
         // JsonIgnore for Model property was introduced in VAPX 1.11-preview2 but later commented out 
@@ -169,6 +170,7 @@ namespace Dax.Metadata
         public List<Measure> Measures { get; }
         public List<UserHierarchy> UserHierarchies { get; }
         public List<Partition> Partitions { get; }
+        public List<Calendar> Calendars { get; }
 
         public IEnumerable<TablePermission> GetTablePermissions()
         {
@@ -222,6 +224,8 @@ namespace Dax.Metadata
             foreach (var p in Partitions) {
                 p.Table = this;
             }
+            foreach (var calendar in Calendars)
+                calendar.Table = this;
 
             if (CalculationGroup != null)
                 CalculationGroup.Table = this;

--- a/src/Dax.Metadata/TimeUnit.cs
+++ b/src/Dax.Metadata/TimeUnit.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+
+namespace Dax.Metadata
+{
+    [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    public enum TimeUnit
+    {
+        Unknown = 0,
+        Year = 1,
+        Semester = 2,
+        SemesterOfYear = 3,
+        Quarter = 4,
+        QuarterOfYear = 5,
+        QuarterOfSemester = 6,
+        Month = 7,
+        MonthOfYear = 8,
+        MonthOfSemester = 9,
+        MonthOfQuarter = 10,
+        Week = 11,
+        WeekOfYear = 12,
+        WeekOfSemester = 13,
+        WeekOfQuarter = 14,
+        WeekOfMonth = 15,
+        Date = 16,
+        DayOfYear = 17,
+        DayOfSemester = 18,
+        DayOfQuarter = 19,
+        DayOfMonth = 20,
+        DayOfWeek = 21
+    }
+}


### PR DESCRIPTION
This pull request introduces support for `Calendar` feature, enabling tables to have associated calendar metadata and supporting advanced time-based grouping and associations. The implementation includes new domain classes, JSON serialization/deserialization logic, and integration into the model extraction process.

**New Calendar feature and model integration:**

* Added new `Calendar` domain model (`Calendar`, `CalendarColumnGroup`, `TimeRelatedColumnGroup`, `TimeUnitColumnAssociation`) to represent calendar metadata, including time-based column groups and associations. (`src/Dax.Metadata/Calendar.cs`, `src/Dax.Metadata/CalendarColumnGroup.cs`, [[1]](diffhunk://#diff-0ed76089056a27e2cad07364b5a27e1113f7ca4d94403f78c0ab3cdf6acf8f78R1-R27) [[2]](diffhunk://#diff-6581cb24df5a280865bdea2e7da354c46538690f6a1393b8f980b7b0c63df40cR1-R27)
* Introduced `TimeUnit` enum to support various time units (year, quarter, month, etc.) for calendar associations. (`src/Dax.Metadata/TimeUnit.cs`, [src/Dax.Metadata/TimeUnit.csR1-R31](diffhunk://#diff-3ee9ab0f5e1717b2d73572003071d58a3934c7f069dbc454ed3df7aa186af527R1-R31))

**Serialization and deserialization improvements:**

* Implemented a custom JSON converter (`CalendarColumnGroupCustomCreationConverter`) to correctly deserialize calendar column group types based on their properties. (`src/Dax.Metadata/JsonConverters/CalendarColumnGroupCustomCreationConverter.cs`, [src/Dax.Metadata/JsonConverters/CalendarColumnGroupCustomCreationConverter.csR1-R42](diffhunk://#diff-da25aa528ebf7758037de9526343bb7780058ce813f87614a5f0fc94dc47dd1fR1-R42))

**Model and extractor integration:**

* Updated the `Table` class to support multiple calendars, including serialization hooks to maintain references. (`src/Dax.Metadata/Table.cs`, [[1]](diffhunk://#diff-6386e9305c53d9ca73e60f1fd1e44992f90d301d2f6c1a9c780646b6f767d06cR28) [[2]](diffhunk://#diff-6386e9305c53d9ca73e60f1fd1e44992f90d301d2f6c1a9c780646b6f767d06cR173) [[3]](diffhunk://#diff-6386e9305c53d9ca73e60f1fd1e44992f90d301d2f6c1a9c780646b6f767d06cR227-R228)
* Enhanced the TOM extractor to extract calendar metadata from TOM tables, including column group and time unit associations. (`src/Dax.Model.Extractor/TomExtractor.cs`, [[1]](diffhunk://#diff-d56b1e47e7b80000e9032f424d11e18448b2118ddee94a3150e3c1f790905decR181-R183) [[2]](diffhunk://#diff-d56b1e47e7b80000e9032f424d11e18448b2118ddee94a3150e3c1f790905decR245-R287)

**Versioning:**

* Incremented the model version to 1.9.0 to reflect the new calendar feature. (`src/Dax.Metadata/Model.cs`, [src/Dax.Metadata/Model.csL114-R114](diffhunk://#diff-1cb47bd2f1be9339500f677776ee75d8273670931d48f5c2f076ad3a6c624fe4L114-R114))