### PR TITLE
Fix: Handle empty Assembly.Location in single-file published apps

### DIFF
--- a/src/Dax.Metadata/Model.cs
+++ b/src/Dax.Metadata/Model.cs
@@ -1,248 +1,232 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 
 namespace Dax.Metadata
 {
-	public class Model
-	{
-		public string DaxModelVersion { get; set; }
-		/// <summary>
-		/// Application that extracts the model info (e.g. DAX Studio, Tabular Editor, ...)
-		/// </summary>
-		public string ExtractorApp { get; set; }
-		/// <summary>
-		/// Version of application that extracts the model info
-		/// </summary>
-		public string ExtractorAppVersion { get; set; }
-		/// <summary>
-		/// Library that extracts the model info (e.g. Dax.Model.Extractor)
-		/// </summary>
-		public string ExtractorLib { get; set; }
-		/// <summary>
-		/// Version of the library that extracts the model info 
-		/// </summary>
-		public string ExtractorLibVersion { get; set; }
-		/// <summary>
-		/// Specifies settings used by the extractor
-		/// </summary>
-		public ExtractorProperties ExtractorProperties { get; set; }
-		/// <summary>
-		/// Library that manages the model info (e.g. Dax.Model)
-		/// </summary>
-		public string DaxModelLib { get; set; }
-		/// <summary>
-		/// LVersion of the library that manages the model info 
-		/// </summary>
-		public string DaxModelLibVersion { get; set; }
-		public string ObfuscatorDictionaryId { get; set; }
-		public string ObfuscatorLib { get; set; }
-		public string ObfuscatorLibVersion { get; set; }
+    public class Model
+    {
+        public string DaxModelVersion { get; set; }
+        /// <summary>
+        /// Application that extracts the model info (e.g. DAX Studio, Tabular Editor, ...)
+        /// </summary>
+        public string ExtractorApp { get; set; }
+        /// <summary>
+        /// Version of application that extracts the model info
+        /// </summary>
+        public string ExtractorAppVersion { get; set; }
+        /// <summary>
+        /// Library that extracts the model info (e.g. Dax.Model.Extractor)
+        /// </summary>
+        public string ExtractorLib { get; set; }
+        /// <summary>
+        /// Version of the library that extracts the model info 
+        /// </summary>
+        public string ExtractorLibVersion { get; set; }
+        /// <summary>
+        /// Specifies settings used by the extractor
+        /// </summary>
+        public ExtractorProperties ExtractorProperties { get; set; }
+        /// <summary>
+        /// Library that manages the model info (e.g. Dax.Model)
+        /// </summary>
+        public string DaxModelLib { get; set; }
+        /// <summary>
+        /// LVersion of the library that manages the model info 
+        /// </summary>
+        public string DaxModelLibVersion { get; set; }
+        public string ObfuscatorDictionaryId { get; set; }
+        public string ObfuscatorLib { get; set; }
+        public string ObfuscatorLibVersion { get; set; }
 
-		public DaxName ServerName { get; set; }
-		public DaxName ModelName { get; set; }
+        public DaxName ServerName { get; set; }
+        public DaxName ModelName { get; set; }
 
-		/// <summary>
-		/// Same compatibility level of TOM database
-		/// </summary>
-		public int CompatibilityLevel { get; set; }
+        /// <summary>
+        /// Same compatibility level of TOM database
+        /// </summary>
+        public int CompatibilityLevel { get; set; }
 
-		/// <summary>
-		/// Same compatibility mode of TOM database
-		/// </summary>
-		public string CompatibilityMode { get; set; }
+        /// <summary>
+        /// Same compatibility mode of TOM database
+        /// </summary>
+        public string CompatibilityMode { get; set; }
 
-		/// <summary>
-		/// Date/time in UTC of last extraction from DMV/TOM
-		/// </summary>
-		public DateTime ExtractionDate { get; set; }
+        /// <summary>
+        /// Date/time in UTC of last extraction from DMV/TOM
+        /// </summary>
+        public DateTime ExtractionDate { get; set; }
 
-		/// <summary>
-		/// Date/time in UTC of the last refresh of the data model
-		/// </summary>
-		public DateTime LastDataRefresh { get; set; }
+        /// <summary>
+        /// Date/time in UTC of the last refresh of the data model
+        /// </summary>
+        public DateTime LastDataRefresh { get; set; }
 
-		/// <summary>
-		/// Same last processed of TOM database
-		/// </summary>
-		public DateTime LastProcessed { get; set; }
+        /// <summary>
+        /// Same last processed of TOM database
+        /// </summary>
+        public DateTime LastProcessed { get; set; }
 
-		/// <summary>
-		/// Same last update of TOM database
-		/// </summary>
-		public DateTime LastUpdate { get; set; }
+        /// <summary>
+        /// Same last update of TOM database
+        /// </summary>
+        public DateTime LastUpdate { get; set; }
 
-		/// <summary>
-		/// Same version of TOM database
-		/// </summary>
-		public long Version { get; set; }
+        /// <summary>
+        /// Same version of TOM database
+        /// </summary>
+        public long Version { get; set; }
 
-		public string ServerPaaSConnectionType { get; set; }
-		public string ServerMode { get; set; }
-		public string ServerLocation { get; set; }
-		public string ServerVersion { get; set; }
+        public string ServerPaaSConnectionType { get; set; }
+        public string ServerMode { get; set; }
+        public string ServerLocation { get; set; }
+        public string ServerVersion { get; set; }
 
-		public List<Table> Tables { get; }
-		public List<Relationship> Relationships { get; }
-		public List<Role> Roles { get; }
-		public List<Function> Functions { get; }
+        public List<Table> Tables { get; }
+        public List<Relationship> Relationships { get; }
+        public List<Role> Roles { get; }
+        public List<Function> Functions { get; }
 
-		/// <summary>
-		/// Default partition mode
-		/// </summary>
-		public Partition.PartitionMode DefaultMode { get; set; }
+        /// <summary>
+        /// Default partition mode
+        /// </summary>
+        public Partition.PartitionMode DefaultMode { get; set; }
 
-		/// <summary>
-		/// Model culture
-		/// </summary>
-		public string Culture { get; set; }
+        /// <summary>
+        /// Model culture
+        /// </summary>
+        public string Culture { get; set; }
 
-		public Model()
-		{
-			ExtractorProperties = new();
-			this.Tables = new List<Table>();
-			this.Relationships = new List<Relationship>();
-			this.Roles = new List<Role>();
-			this.Functions = new List<Function>();
-		}
+        public Model()
+        {
+            ExtractorProperties = new();
+            this.Tables = new List<Table>();
+            this.Relationships = new List<Relationship>();
+            this.Roles = new List<Role>();
+            this.Functions = new List<Function>();
+        }
 
-		// Manually update the version each time the DaxModel is modified - use https://semver.org/ specification
-		[JsonIgnore]
-		public static readonly string CurrentDaxModelVersion = new Version(1, 9, 0).ToString(3);
+        // Manually update the version each time the DaxModel is modified - use https://semver.org/ specification
+        [JsonIgnore]
+        public static readonly string CurrentDaxModelVersion = new Version(1, 9, 0).ToString(3);
 
-		public Model(string extractorLib, string extractorLibVersion, string extractorApp = null, string extractorAppVersion = null) : this()
-		{
-			this.ExtractorLib = extractorLib;
-			this.ExtractorLibVersion = extractorLibVersion;
-			this.ExtractorApp = extractorApp;
-			this.ExtractorAppVersion = extractorAppVersion;
+        public Model(string extractorLib, string extractorLibVersion, string extractorApp = null, string extractorAppVersion = null) : this()
+        {
+            this.ExtractorLib = extractorLib;
+            this.ExtractorLibVersion = extractorLibVersion;
+            this.ExtractorApp = extractorApp;
+            this.ExtractorAppVersion = extractorAppVersion;
 
-			var modelAssembly = this.GetType().Assembly;
-			var modelAssemblyName = modelAssembly.GetName();
+            var modelAssembly = this.GetType().Assembly;
+            var modelAssemblyName = modelAssembly.GetName();
+            var modelVersion = modelAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
 
-			string modelVersion;
-			if (!string.IsNullOrEmpty(modelAssembly.Location))
-			{
-				var modelFileVersionInfo = FileVersionInfo.GetVersionInfo(modelAssembly.Location);
-				modelVersion = modelFileVersionInfo.ProductVersion;
-			}
-			else
-			{
-				// Single-file published apps bundle assemblies in memory,
-				// so Assembly.Location is empty. Fall back to informational version.
-				modelVersion = modelAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-					?.InformationalVersion
-					?? modelAssemblyName.Version?.ToString()
-					?? "0.0.0";
-			}
+            this.DaxModelVersion = CurrentDaxModelVersion;
+            this.DaxModelLib = modelAssemblyName.Name;
+            this.DaxModelLibVersion = modelVersion;
+        }
 
-			this.DaxModelVersion = CurrentDaxModelVersion;
-			this.DaxModelLib = modelAssemblyName.Name;
-			this.DaxModelLibVersion = modelVersion;
-		}
+        [OnDeserialized]
+        internal void OnDeserializedMethod(StreamingContext context)
+        {
+            foreach (var t in Tables)
+                t.Model = this;
 
-		[OnDeserialized]
-		internal void OnDeserializedMethod(StreamingContext context)
-		{
-			foreach (var t in Tables)
-				t.Model = this;
+            // TODO: Add the Model property to Relationship, as done for other top-level entities
+            //foreach (var r in Relationships)
+            //    r.Model = this;
 
-			// TODO: Add the Model property to Relationship, as done for other top-level entities
-			//foreach (var r in Relationships)
-			//    r.Model = this;
+            foreach (var r in Roles)
+                r.Model = this;
 
-			foreach (var r in Roles)
-				r.Model = this;
+            foreach (var f in Functions)
+                f.Model = this;
+        }
 
-			foreach (var f in Functions)
-				f.Model = this;
-		}
+        /*
+        public void PopulateColumnReferences()
+        {
+            var columns = from t in this.Tables
+                          from c in t.Columns
+                          select c;
 
-		/*
-		public void PopulateColumnReferences()
-		{
-			var columns = from t in this.Tables
-						  from c in t.Columns
-						  select c;
+            // Set IsReferenced of each column in the model
+            // This initial scan set to true/false only
+            foreach ( var c in columns )
+            {
+                c.IsReferenced = (FindReferences(c, true).Count > 0);
+            }
 
-			// Set IsReferenced of each column in the model
-			// This initial scan set to true/false only
-			foreach ( var c in columns )
-			{
-				c.IsReferenced = (FindReferences(c, true).Count > 0);
-			}
+            // Following scan set to TRUE columns that should be FALSE otherwise
+            // We have to run these scans after the previous loop that resets the IsReferenced value
 
-			// Following scan set to TRUE columns that should be FALSE otherwise
-			// We have to run these scans after the previous loop that resets the IsReferenced value
+            // Relationship
+            
+            // Order by
+        }
 
-			// Relationship
-			
-			// Order by
-		}
+        public List<object> FindReferences( Column column, bool findFirstOnly )
+        {
+            var result = new List<object>();
 
-		public List<object> FindReferences( Column column, bool findFirstOnly )
-		{
-			var result = new List<object>();
+            // We use the unqualified table name
+            // A more reliable analysis requires a complete DAX parser
+            string columnReferenceName = $"[{column.ColumnName.Name}]";
 
-			// We use the unqualified table name
-			// A more reliable analysis requires a complete DAX parser
-			string columnReferenceName = $"[{column.ColumnName.Name}]";
+            // Scan columns 
+            IEnumerable<object> columnExpressions =
+                from t in this.Tables
+                from c in t.Columns
+                where (c.ColumnExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                select c;
+            
+            // Scan measures
+            IEnumerable<object> measureExpressions = 
+                from t in this.Tables
+                from m in t.Measures
+                where (m.MeasureExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                    || (m.DetailRowsExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                    || (m.KpiStatusExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                    || (m.KpiTargetExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                    || (m.KpiTrendExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                select m;
 
-			// Scan columns 
-			IEnumerable<object> columnExpressions =
-				from t in this.Tables
-				from c in t.Columns
-				where (c.ColumnExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-				select c;
-			
-			// Scan measures
-			IEnumerable<object> measureExpressions = 
-				from t in this.Tables
-				from m in t.Measures
-				where (m.MeasureExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-					|| (m.DetailRowsExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-					|| (m.KpiStatusExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-					|| (m.KpiTargetExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-					|| (m.KpiTrendExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-				select m;
+            // Scan calculated tables
+            IEnumerable<object> tableExpressions = 
+                from t in this.Tables
+                where (t.TableExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                select t;
 
-			// Scan calculated tables
-			IEnumerable<object> tableExpressions = 
-				from t in this.Tables
-				where (t.TableExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-				select t;
+            // Scan calculation groups
+            IEnumerable<object> calculationItemExpressions = 
+                from t in this.Tables
+                where t.CalculationGroup != null
+                from ci in t.CalculationGroup.CalculationItems
+                where (ci.ItemExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                    || (ci.FormatStringDefinition?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+                select ci;
 
-			// Scan calculation groups
-			IEnumerable<object> calculationItemExpressions = 
-				from t in this.Tables
-				where t.CalculationGroup != null
-				from ci in t.CalculationGroup.CalculationItems
-				where (ci.ItemExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-					|| (ci.FormatStringDefinition?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-				select ci;
+            var completeList = columnExpressions.Union(measureExpressions).Union(tableExpressions).Union(calculationItemExpressions);
 
-			var completeList = columnExpressions.Union(measureExpressions).Union(tableExpressions).Union(calculationItemExpressions);
+            foreach (var o in completeList)
+            {
+                if (findFirstOnly && result.Count > 0) break;
+                result.Add(o);
+            }
 
-			foreach (var o in completeList)
-			{
-				if (findFirstOnly && result.Count > 0) break;
-				result.Add(o);
-			}
+            return result;
+        }
+        */
+    }
 
-			return result;
-		}
-		*/
-	}
-
-	public static class ModelExtensions
-	{
-		public static bool HasDirectLakePartitions(this Model model)
-		{
-			return model.Tables.Any((t) => t.HasDirectLakePartitions);
-		}
-	}
+    public static class ModelExtensions
+    {
+        public static bool HasDirectLakePartitions(this Model model)
+        {
+            return model.Tables.Any((t) => t.HasDirectLakePartitions);
+        }
+    }
 }

--- a/src/Dax.Metadata/Model.cs
+++ b/src/Dax.Metadata/Model.cs
@@ -3,230 +3,246 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.Serialization;
 
 namespace Dax.Metadata
 {
-    public class Model
-    {
-        public string DaxModelVersion { get; set; }
-        /// <summary>
-        /// Application that extracts the model info (e.g. DAX Studio, Tabular Editor, ...)
-        /// </summary>
-        public string ExtractorApp { get; set; }
-        /// <summary>
-        /// Version of application that extracts the model info
-        /// </summary>
-        public string ExtractorAppVersion { get; set; }
-        /// <summary>
-        /// Library that extracts the model info (e.g. Dax.Model.Extractor)
-        /// </summary>
-        public string ExtractorLib { get; set; }
-        /// <summary>
-        /// Version of the library that extracts the model info 
-        /// </summary>
-        public string ExtractorLibVersion { get; set; }
-        /// <summary>
-        /// Specifies settings used by the extractor
-        /// </summary>
-        public ExtractorProperties ExtractorProperties { get; set; }
-        /// <summary>
-        /// Library that manages the model info (e.g. Dax.Model)
-        /// </summary>
-        public string DaxModelLib { get; set; }
-        /// <summary>
-        /// LVersion of the library that manages the model info 
-        /// </summary>
-        public string DaxModelLibVersion { get; set; }
-        public string ObfuscatorDictionaryId { get; set; }
-        public string ObfuscatorLib { get; set; }
-        public string ObfuscatorLibVersion { get; set; }
+	public class Model
+	{
+		public string DaxModelVersion { get; set; }
+		/// <summary>
+		/// Application that extracts the model info (e.g. DAX Studio, Tabular Editor, ...)
+		/// </summary>
+		public string ExtractorApp { get; set; }
+		/// <summary>
+		/// Version of application that extracts the model info
+		/// </summary>
+		public string ExtractorAppVersion { get; set; }
+		/// <summary>
+		/// Library that extracts the model info (e.g. Dax.Model.Extractor)
+		/// </summary>
+		public string ExtractorLib { get; set; }
+		/// <summary>
+		/// Version of the library that extracts the model info 
+		/// </summary>
+		public string ExtractorLibVersion { get; set; }
+		/// <summary>
+		/// Specifies settings used by the extractor
+		/// </summary>
+		public ExtractorProperties ExtractorProperties { get; set; }
+		/// <summary>
+		/// Library that manages the model info (e.g. Dax.Model)
+		/// </summary>
+		public string DaxModelLib { get; set; }
+		/// <summary>
+		/// LVersion of the library that manages the model info 
+		/// </summary>
+		public string DaxModelLibVersion { get; set; }
+		public string ObfuscatorDictionaryId { get; set; }
+		public string ObfuscatorLib { get; set; }
+		public string ObfuscatorLibVersion { get; set; }
 
-        public DaxName ServerName { get; set; }
-        public DaxName ModelName { get; set; }
+		public DaxName ServerName { get; set; }
+		public DaxName ModelName { get; set; }
 
-        /// <summary>
-        /// Same compatibility level of TOM database
-        /// </summary>
-        public int CompatibilityLevel { get; set; }
+		/// <summary>
+		/// Same compatibility level of TOM database
+		/// </summary>
+		public int CompatibilityLevel { get; set; }
 
-        /// <summary>
-        /// Same compatibility mode of TOM database
-        /// </summary>
-        public string CompatibilityMode { get; set; }
+		/// <summary>
+		/// Same compatibility mode of TOM database
+		/// </summary>
+		public string CompatibilityMode { get; set; }
 
-        /// <summary>
-        /// Date/time in UTC of last extraction from DMV/TOM
-        /// </summary>
-        public DateTime ExtractionDate { get; set; }
+		/// <summary>
+		/// Date/time in UTC of last extraction from DMV/TOM
+		/// </summary>
+		public DateTime ExtractionDate { get; set; }
 
-        /// <summary>
-        /// Date/time in UTC of the last refresh of the data model
-        /// </summary>
-        public DateTime LastDataRefresh { get; set; }
+		/// <summary>
+		/// Date/time in UTC of the last refresh of the data model
+		/// </summary>
+		public DateTime LastDataRefresh { get; set; }
 
-        /// <summary>
-        /// Same last processed of TOM database
-        /// </summary>
-        public DateTime LastProcessed { get; set; }
+		/// <summary>
+		/// Same last processed of TOM database
+		/// </summary>
+		public DateTime LastProcessed { get; set; }
 
-        /// <summary>
-        /// Same last update of TOM database
-        /// </summary>
-        public DateTime LastUpdate { get; set; }
+		/// <summary>
+		/// Same last update of TOM database
+		/// </summary>
+		public DateTime LastUpdate { get; set; }
 
-        /// <summary>
-        /// Same version of TOM database
-        /// </summary>
-        public long Version { get; set; }
+		/// <summary>
+		/// Same version of TOM database
+		/// </summary>
+		public long Version { get; set; }
 
-        public string ServerPaaSConnectionType { get; set; }
-        public string ServerMode { get; set; }
-        public string ServerLocation { get; set; }
-        public string ServerVersion { get; set; }
+		public string ServerPaaSConnectionType { get; set; }
+		public string ServerMode { get; set; }
+		public string ServerLocation { get; set; }
+		public string ServerVersion { get; set; }
 
-        public List<Table> Tables { get; }
-        public List<Relationship> Relationships { get; }
-        public List<Role> Roles { get; }
-        public List<Function> Functions { get; }
+		public List<Table> Tables { get; }
+		public List<Relationship> Relationships { get; }
+		public List<Role> Roles { get; }
+		public List<Function> Functions { get; }
 
-        /// <summary>
-        /// Default partition mode
-        /// </summary>
-        public Partition.PartitionMode DefaultMode { get; set; }
+		/// <summary>
+		/// Default partition mode
+		/// </summary>
+		public Partition.PartitionMode DefaultMode { get; set; }
 
-        /// <summary>
-        /// Model culture
-        /// </summary>
-        public string Culture { get; set; }
+		/// <summary>
+		/// Model culture
+		/// </summary>
+		public string Culture { get; set; }
 
-        public Model()
-        {
-            ExtractorProperties = new();
-            this.Tables = new List<Table>();
-            this.Relationships = new List<Relationship>();
-            this.Roles = new List<Role>();
-            this.Functions = new List<Function>();
-        }
+		public Model()
+		{
+			ExtractorProperties = new();
+			this.Tables = new List<Table>();
+			this.Relationships = new List<Relationship>();
+			this.Roles = new List<Role>();
+			this.Functions = new List<Function>();
+		}
 
-        // Manually update the version each time the DaxModel is modified - use https://semver.org/ specification
-        [JsonIgnore]
-        public static readonly string CurrentDaxModelVersion = new Version(1, 9, 0).ToString(3);
+		// Manually update the version each time the DaxModel is modified - use https://semver.org/ specification
+		[JsonIgnore]
+		public static readonly string CurrentDaxModelVersion = new Version(1, 9, 0).ToString(3);
 
-        public Model(string extractorLib, string extractorLibVersion, string extractorApp = null, string extractorAppVersion = null) : this()
-        {
-            this.ExtractorLib = extractorLib;
-            this.ExtractorLibVersion = extractorLibVersion;
-            this.ExtractorApp = extractorApp;
-            this.ExtractorAppVersion = extractorAppVersion;
+		public Model(string extractorLib, string extractorLibVersion, string extractorApp = null, string extractorAppVersion = null) : this()
+		{
+			this.ExtractorLib = extractorLib;
+			this.ExtractorLibVersion = extractorLibVersion;
+			this.ExtractorApp = extractorApp;
+			this.ExtractorAppVersion = extractorAppVersion;
 
-            var modelAssembly = this.GetType().Assembly;
-            var modelAssemblyName = modelAssembly.GetName();
-            var modelFileVersionInfo = FileVersionInfo.GetVersionInfo(modelAssembly.Location);
+			var modelAssembly = this.GetType().Assembly;
+			var modelAssemblyName = modelAssembly.GetName();
 
-            this.DaxModelVersion = CurrentDaxModelVersion;
-            this.DaxModelLib = modelAssemblyName.Name;
-            this.DaxModelLibVersion = modelFileVersionInfo.ProductVersion; // e.g. CI build: 1.2.5-preview2+<git-commit-hash> , RELEASE build: 1.2.5
-        }
+			string modelVersion;
+			if (!string.IsNullOrEmpty(modelAssembly.Location))
+			{
+				var modelFileVersionInfo = FileVersionInfo.GetVersionInfo(modelAssembly.Location);
+				modelVersion = modelFileVersionInfo.ProductVersion;
+			}
+			else
+			{
+				// Single-file published apps bundle assemblies in memory,
+				// so Assembly.Location is empty. Fall back to informational version.
+				modelVersion = modelAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+					?.InformationalVersion
+					?? modelAssemblyName.Version?.ToString()
+					?? "0.0.0";
+			}
 
-        [OnDeserialized]
-        internal void OnDeserializedMethod(StreamingContext context)
-        {
-            foreach (var t in Tables)
-                t.Model = this;
+			this.DaxModelVersion = CurrentDaxModelVersion;
+			this.DaxModelLib = modelAssemblyName.Name;
+			this.DaxModelLibVersion = modelVersion;
+		}
 
-            // TODO: Add the Model property to Relationship, as done for other top-level entities
-            //foreach (var r in Relationships)
-            //    r.Model = this;
+		[OnDeserialized]
+		internal void OnDeserializedMethod(StreamingContext context)
+		{
+			foreach (var t in Tables)
+				t.Model = this;
 
-            foreach (var r in Roles)
-                r.Model = this;
+			// TODO: Add the Model property to Relationship, as done for other top-level entities
+			//foreach (var r in Relationships)
+			//    r.Model = this;
 
-            foreach (var f in Functions)
-                f.Model = this;
-        }
+			foreach (var r in Roles)
+				r.Model = this;
 
-        /*
-        public void PopulateColumnReferences()
-        {
-            var columns = from t in this.Tables
-                          from c in t.Columns
-                          select c;
+			foreach (var f in Functions)
+				f.Model = this;
+		}
 
-            // Set IsReferenced of each column in the model
-            // This initial scan set to true/false only
-            foreach ( var c in columns )
-            {
-                c.IsReferenced = (FindReferences(c, true).Count > 0);
-            }
+		/*
+		public void PopulateColumnReferences()
+		{
+			var columns = from t in this.Tables
+						  from c in t.Columns
+						  select c;
 
-            // Following scan set to TRUE columns that should be FALSE otherwise
-            // We have to run these scans after the previous loop that resets the IsReferenced value
+			// Set IsReferenced of each column in the model
+			// This initial scan set to true/false only
+			foreach ( var c in columns )
+			{
+				c.IsReferenced = (FindReferences(c, true).Count > 0);
+			}
 
-            // Relationship
-            
-            // Order by
-        }
+			// Following scan set to TRUE columns that should be FALSE otherwise
+			// We have to run these scans after the previous loop that resets the IsReferenced value
 
-        public List<object> FindReferences( Column column, bool findFirstOnly )
-        {
-            var result = new List<object>();
+			// Relationship
+			
+			// Order by
+		}
 
-            // We use the unqualified table name
-            // A more reliable analysis requires a complete DAX parser
-            string columnReferenceName = $"[{column.ColumnName.Name}]";
+		public List<object> FindReferences( Column column, bool findFirstOnly )
+		{
+			var result = new List<object>();
 
-            // Scan columns 
-            IEnumerable<object> columnExpressions =
-                from t in this.Tables
-                from c in t.Columns
-                where (c.ColumnExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                select c;
-            
-            // Scan measures
-            IEnumerable<object> measureExpressions = 
-                from t in this.Tables
-                from m in t.Measures
-                where (m.MeasureExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                    || (m.DetailRowsExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                    || (m.KpiStatusExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                    || (m.KpiTargetExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                    || (m.KpiTrendExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                select m;
+			// We use the unqualified table name
+			// A more reliable analysis requires a complete DAX parser
+			string columnReferenceName = $"[{column.ColumnName.Name}]";
 
-            // Scan calculated tables
-            IEnumerable<object> tableExpressions = 
-                from t in this.Tables
-                where (t.TableExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                select t;
+			// Scan columns 
+			IEnumerable<object> columnExpressions =
+				from t in this.Tables
+				from c in t.Columns
+				where (c.ColumnExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+				select c;
+			
+			// Scan measures
+			IEnumerable<object> measureExpressions = 
+				from t in this.Tables
+				from m in t.Measures
+				where (m.MeasureExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+					|| (m.DetailRowsExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+					|| (m.KpiStatusExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+					|| (m.KpiTargetExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+					|| (m.KpiTrendExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+				select m;
 
-            // Scan calculation groups
-            IEnumerable<object> calculationItemExpressions = 
-                from t in this.Tables
-                where t.CalculationGroup != null
-                from ci in t.CalculationGroup.CalculationItems
-                where (ci.ItemExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                    || (ci.FormatStringDefinition?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
-                select ci;
+			// Scan calculated tables
+			IEnumerable<object> tableExpressions = 
+				from t in this.Tables
+				where (t.TableExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+				select t;
 
-            var completeList = columnExpressions.Union(measureExpressions).Union(tableExpressions).Union(calculationItemExpressions);
+			// Scan calculation groups
+			IEnumerable<object> calculationItemExpressions = 
+				from t in this.Tables
+				where t.CalculationGroup != null
+				from ci in t.CalculationGroup.CalculationItems
+				where (ci.ItemExpression?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+					|| (ci.FormatStringDefinition?.Expression?.Contains(columnReferenceName)).GetValueOrDefault()
+				select ci;
 
-            foreach (var o in completeList)
-            {
-                if (findFirstOnly && result.Count > 0) break;
-                result.Add(o);
-            }
+			var completeList = columnExpressions.Union(measureExpressions).Union(tableExpressions).Union(calculationItemExpressions);
 
-            return result;
-        }
-        */
-    }
+			foreach (var o in completeList)
+			{
+				if (findFirstOnly && result.Count > 0) break;
+				result.Add(o);
+			}
 
-    public static class ModelExtensions
-    {
-        public static bool HasDirectLakePartitions(this Model model)
-        {
-            return model.Tables.Any((t) => t.HasDirectLakePartitions);
-        }
-    }
+			return result;
+		}
+		*/
+	}
+
+	public static class ModelExtensions
+	{
+		public static bool HasDirectLakePartitions(this Model model)
+		{
+			return model.Tables.Any((t) => t.HasDirectLakePartitions);
+		}
+	}
 }

--- a/src/Dax.Model.Extractor/Util.cs
+++ b/src/Dax.Model.Extractor/Util.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using Tom = Microsoft.AnalysisServices;
+using System.Reflection;
 
 namespace Dax.Model.Extractor
 {
@@ -28,12 +29,27 @@ namespace Dax.Model.Extractor
 
             var assembly = extractorInstance.GetType().Assembly;
             var assemblyName = assembly.GetName();
-            var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+
+            string version;
+            if (!string.IsNullOrEmpty(assembly.Location))
+            {
+                var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+                version = fileVersionInfo.ProductVersion;
+            }
+            else
+            {
+                // Single-file published apps bundle assemblies in memory, 
+                // so Assembly.Location is empty. Fall back to informational version.
+                version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion
+                    ?? assemblyName.Version?.ToString()
+                    ?? "0.0.0";
+            }
 
             return new ExtractorInfo
             {
                 Name = assemblyName.Name,
-                Version = fileVersionInfo.ProductVersion
+                Version = version
             };
         }
 

--- a/src/Dax.Model.Extractor/Util.cs
+++ b/src/Dax.Model.Extractor/Util.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using Tom = Microsoft.AnalysisServices;
 using System.Reflection;
 
@@ -29,22 +28,7 @@ namespace Dax.Model.Extractor
 
             var assembly = extractorInstance.GetType().Assembly;
             var assemblyName = assembly.GetName();
-
-            string version;
-            if (!string.IsNullOrEmpty(assembly.Location))
-            {
-                var fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
-                version = fileVersionInfo.ProductVersion;
-            }
-            else
-            {
-                // Single-file published apps bundle assemblies in memory, 
-                // so Assembly.Location is empty. Fall back to informational version.
-                version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                    ?.InformationalVersion
-                    ?? assemblyName.Version?.ToString()
-                    ?? "0.0.0";
-            }
+            var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
 
             return new ExtractorInfo
             {


### PR DESCRIPTION
### Problem

Two places in the codebase call `FileVersionInfo.GetVersionInfo(assembly.Location)`:

- `Util.GetExtractorInfo()` in `Dax.Model.Extractor`
- `Model()` constructor in `Dax.Metadata`

Both throw an `ArgumentException` when the consuming application is published as a .NET single-file executable. In single-file mode, managed assemblies are loaded from memory and `Assembly.Location` returns an empty string, causing `Path.GetFullPath("")` to fail.

This makes it impossible to use `TomExtractor.GetDaxModel()` from a single-file app without setting `IncludeAllContentForSelfExtract=true`, which forces all bundled content to be extracted to a temp directory on disk. This is defeating much of the benefit of single-file publishing.

### Fix

Use `AssemblyInformationalVersionAttribute` for version retrieval. Standardize on `AssemblyInformationalVersionAttribute` instead of `FileVersionInfo`, which requires `Assembly.Location`. This provides a single consistent approach across all deployment types including single-file published apps.

**Files changed:**
- `src/Dax.Model.Extractor/Util.cs` — `GetExtractorInfo()`
- `src/Dax.Metadata/Model.cs` — `Model()` constructor

### Impact

No behavior change for existing consumers.